### PR TITLE
Enable connecting build-image(s) to releases

### DIFF
--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -60,8 +60,8 @@ class BuildImageFilter(django_filters.FilterSet):
                                                           widget=SelectMultiple)
     else:
         component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
-    version                 = MultiValueFilter(name='rpms__version', distinct=True)
-    release                 = MultiValueFilter(name='rpms__release', distinct=True)
+    rpm_version                 = MultiValueFilter(name='rpms__version', distinct=True)
+    rpm_release                 = MultiValueFilter(name='rpms__release', distinct=True)
 
     image_id                = MultiValueFilter()
     image_format            = MultiValueFilter(name='image_format__name')
@@ -71,6 +71,7 @@ class BuildImageFilter(django_filters.FilterSet):
     archive_name            = MultiValueFilter(name='archives__name', distinct=True)
     archive_size            = MultiValueFilter(name='archives__size', distinct=True)
     archive_md5             = MultiValueFilter(name='archives__md5', distinct=True)
+    release_id              = MultiValueFilter(name='releases__release_id', distinct=True)
 
     def filter_by_component_name(self, queryset, value):
         from pdc.apps.bindings import models as binding_models
@@ -86,5 +87,5 @@ class BuildImageFilter(django_filters.FilterSet):
 
     class Meta:
         model = models.BuildImage
-        fields = ('component_name', 'version', 'release', 'image_id', 'image_format', 'md5', 'archive_build_nvr',
-                  'archive_name', 'archive_size', 'archive_md5')
+        fields = ('component_name', 'rpm_version', 'rpm_release', 'image_id', 'image_format', 'md5',
+                  'archive_build_nvr', 'archive_name', 'archive_size', 'archive_md5', 'release_id')

--- a/pdc/apps/package/fixtures/test/build_image.json
+++ b/pdc/apps/package/fixtures/test/build_image.json
@@ -9,6 +9,7 @@
             1,
             2
         ],
+        "releases": [1],
         "image_id": "my-server-docker-1.0-27",
         "md5": "0123456789abcdef0123456789abcdef"
     }
@@ -23,6 +24,7 @@
             3,
             4
         ],
+        "releases": [1, 2],
         "image_id": "my-client-docker",
         "md5": "abcdef0123456789abcdef0123456789"
     }

--- a/pdc/apps/package/fixtures/test/release.json
+++ b/pdc/apps/package/fixtures/test/release.json
@@ -1,0 +1,28 @@
+[
+  {
+    "model": "release.Release",
+    "pk": 1,
+    "fields": {
+      "release_type": 1,
+      "release_id": "release-1.0",
+      "short": "release",
+      "name": "Test Release",
+      "version": "1.0",
+      "base_product": null,
+      "active": true
+    }
+  },
+  {
+    "model": "release.Release",
+    "pk": 2,
+    "fields": {
+      "release_type": 1,
+      "release_id": "release-2.0",
+      "short": "release",
+      "name": "Test Release",
+      "version": "2.0",
+      "base_product": null,
+      "active": true
+    }
+  }
+]

--- a/pdc/apps/package/migrations/0003_buildimage_releases.py
+++ b/pdc/apps/package/migrations/0003_buildimage_releases.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('release', '0002_auto_20150512_0719'),
+        ('package', '0002_auto_20150512_0714'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='buildimage',
+            name='releases',
+            field=models.ManyToManyField(to='release.Release'),
+        ),
+    ]

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -172,6 +172,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                         "md5":           string,         # required
                     }
                     ...
+                ],                                       # optional
+                'releases': [
+                        release_id,      string          # optional
+                        ......
                 ]                                        # optional
             }
 
@@ -197,6 +201,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                         "md5":           string,
                     }
                     ...
+                ],
+                'releases': [
+                        "release_id",   string
+                        ......
                 ]
             }
         """
@@ -211,8 +219,9 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
         __Query params__:
 
          * component_name: srpm_name or release_component_name if release_component srpm mapping exists
-         * version       : rpm nvr's version
-         * release       : rpm nvr's release
+         * rpm_version       : rpm nvr's version
+         * rpm_release       : rpm nvr's release
+         * release_id        : product release id
          * image_id
          * image_format
          * md5
@@ -246,6 +255,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                             "md5":           string,
                         }
                         ...
+                    ],
+                    'releases': [
+                        "release_id",   string
+                        ......
                     ]
                 },
                 ...
@@ -281,6 +294,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                         "md5":           string,
                     }
                     ...
+                ],
+                'releases': [
+                        "release_id",   string
+                        ......
                 ]
             }
         """
@@ -316,6 +333,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                         "md5":           string,
                     }
                     ...
+                ],
+                'releases': [
+                        "release_id",   string
+                        ......
                 ]
             }
 
@@ -350,6 +371,10 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                         "md5":           string,
                     }
                     ...
+                ],
+                'releases': [
+                        "release_id",   string
+                        ......
                 ]
             }
         """


### PR DESCRIPTION
1. Connect build-image to releases. They have many to many
relationship now.
2. Change old build-image's release and version to rpm_release
and rpm_version. Now use latter to filter build images.