### PR TITLE
Refactor resource url field to id in component app

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -236,7 +236,7 @@ class GlobalComponentSerializer(DynamicFieldsSerializerMixin,
 
     class Meta:
         model = GlobalComponent
-        fields = ('url', 'name', 'dist_git_path', 'dist_git_web_url', 'contacts', 'labels', 'upstream')
+        fields = ('id', 'name', 'dist_git_path', 'dist_git_web_url', 'contacts', 'labels', 'upstream')
 
 
 class TreeForeignKeyField(serializers.Field):
@@ -295,7 +295,7 @@ class BugzillaComponentSerializer(DynamicFieldsSerializerMixin,
 
     class Meta:
         model = BugzillaComponent
-        fields = ('url', 'name', 'parent_component', 'subcomponents')
+        fields = ('id', 'name', 'parent_component', 'subcomponents')
 
 
 class ReleaseField(serializers.Field):
@@ -413,7 +413,7 @@ class ReleaseComponentSerializer(DynamicFieldsSerializerMixin,
 
     class Meta:
         model = ReleaseComponent
-        fields = ('url', 'release', 'bugzilla_component', 'brew_package', 'global_component',
+        fields = ('id', 'release', 'bugzilla_component', 'brew_package', 'global_component',
                   'name', 'dist_git_branch', 'dist_git_web_url', 'active',
                   'contacts', 'type')
         validators = [UniqueTogetherValidator(

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -57,7 +57,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         data = {'name': 'TestCaseComponent', 'dist_git_path': 'python'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        del response.data['url']
+        del response.data['id']
         del response.data['dist_git_web_url']
         data.update({'contacts': []})
         data.update({'labels': []})
@@ -76,7 +76,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         data = {'name': 'TestCaseComponent', 'dist_git_path': 'python', 'labels': [{'name': 'label1', 'description': 'abc'}]}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        del response.data['url']
+        del response.data['id']
         del response.data['dist_git_web_url']
         data.update({'contacts': []})
         data.update({'labels': []})
@@ -90,7 +90,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
                              'scm_url': 'http://svn.python.org/moduleX'}}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        del response.data['url']
+        del response.data['id']
         del response.data['dist_git_web_url']
         data.update({'contacts': []})
         data.update({'labels': []})
@@ -102,7 +102,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
                              'scm_url': 'http://svn.python.org/moduleX22'}}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        del response.data['url']
+        del response.data['id']
         del response.data['dist_git_web_url']
         data.update({'contacts': []})
         data.update({'labels': []})
@@ -113,7 +113,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         data = {'name': 'Updated', 'dist_git_path': 'python'}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        del response.data['url']
+        del response.data['id']
         del response.data['dist_git_web_url']
         del response.data['contacts']
         del response.data['labels']
@@ -777,7 +777,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_filter_fields_not_affect_bugzilla_component(self):
         url = reverse('releasecomponent-list')
-        response = self.client.get(url + '?fields=bugzilla_component&fields=url', format='json')
+        response = self.client.get(url + '?fields=bugzilla_component', format='json')
         self.assertGreater(response.data['results'][0]['bugzilla_component'], 1)
 
     def test_filter_release_component_by_inactive(self):
@@ -830,7 +830,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         del response.data['dist_git_web_url']
         del response.data['srpm']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'url': url,
+        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'id': 3,
                      'bugzilla_component': None, 'active': True, 'type': None})
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])
@@ -843,7 +843,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         del response.data['dist_git_web_url']
         del response.data['srpm']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'url': url,
+        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'id': 3,
                      'bugzilla_component': None, 'active': True, 'type': 'rpm'})
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])
@@ -953,7 +953,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         del response.data['dist_git_branch']
         del response.data['contacts']
         del response.data['srpm']
-        del response.data['url']
+        del response.data['id']
         del response.data['bugzilla_component']
         del response.data['brew_package']
         del response.data['type']
@@ -1025,7 +1025,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.post(url, data, format='json')
         del response.data['dist_git_web_url']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'url': url,
+        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'id': 3,
                      'bugzilla_component': None, 'srpm': None, 'active': True, 'type': None})
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])
@@ -1035,7 +1035,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.post(url, data, format='json')
         del response.data['dist_git_web_url']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'url': url,
+        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'id': 3,
                      'bugzilla_component': None, 'srpm': None, 'active': True, 'type': None})
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1, 1])
@@ -1046,7 +1046,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.post(url, data, format='json')
         del response.data['dist_git_web_url']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'url': url,
+        data.update({'contacts': [], 'dist_git_branch': "release_branch", 'id': 3,
                      'bugzilla_component': None, 'srpm': None, 'active': False, 'type': None})
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -119,7 +119,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
                 "previous": url,
                 "results": [
                     {
-                        "url": url,
+                        "id": int,
                         "name": string,
                         "dist_git_path": <string|null>,
                         "dist_git_web_url": string,
@@ -160,7 +160,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "dist_git_path": <string|null>,
                 "dist_git_web_url": string,
@@ -206,7 +206,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "dist_git_path": string,
                 "dist_git_web_url": string,
@@ -220,7 +220,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
             curl -X POST -H "Content-Type: application/json" %(HOST_NAME)s/%(API_PATH)s/global-components/ -d '{ "name": "Demo", "dist_git_path": "rpm/Demo"}'
             # output
             {
-                "url": "%(HOST_NAME)s/%(API_PATH)s/global-components/4181/",
+                "id": 4181,
                 "name": "Demo",
                 "dist_git_path": "rpm/Demo",
                 "dist_git_web_url": "http://pkgs.example.com/cgit/rpms/rpm/Demo"
@@ -256,7 +256,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "dist_git_path": string,
                 "dist_git_web_url": string,
@@ -276,7 +276,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
             curl -X PUT -H "Content-Type: application/json" %(HOST_NAME)s/%(API_PATH)s/global-components/4181/ -d '{"name": "Demo1", "dist_git_path": "rpm/Demo1"}'
             # output
             {
-                "url": "%(HOST_NAME)s/%(API_PATH)s/global-components/4181/",
+                "id": 4181,
                 "name": "Demo",
                 "dist_git_path": "rpm/Demo1",
                 "dist_git_web_url": "http://pkgs.example.com/cgit/rpms/rpm/Demo1"
@@ -290,7 +290,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
             curl -X PATCH -H "Content-Type: application/json" %(HOST_NAME)s/%(API_PATH)s/global-components/4181/ -d '{"dist_git_path": "rpm/Demo1"}'
             # output
             {
-                "url": "%(HOST_NAME)s/%(API_PATH)s/global-components/4181/",
+                "id": 4181,
                 "name": "Demo",
                 "dist_git_path": "rpm/Demo1",
                 "dist_git_web_url": "http://pkgs.example.com/cgit/rpms/rpm/Demo1"
@@ -733,14 +733,14 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
                 "previous": url,
                 "results": [
                     {
-                        "url": url,
+                        "id": int,
                         "release": {
                             "release_id": string,
                             "active": bool
                         },
                         "global_component": string,
                         "bugzilla_component": {
-                            "url": url,
+                            "id": int,
                             "name": string,
                             "parent_component": string,
                             "subcomponents": [
@@ -777,14 +777,14 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "release": {
                     "release_id": string,
                     "active": bool
                 },
                 "global_component": string,
                 "bugzilla_component": {
-                    "url": url,
+                    "id": int,
                     "name": string,
                     "parent_component": string,
                     "subcomponents": [
@@ -862,7 +862,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "release": {
                     "release_id": string,
                     "active": bool
@@ -932,7 +932,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "release": {
                     "release_id": string,
                     "active": bool
@@ -944,7 +944,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
                 "dist_git_web_url": string,
                 "active": true,
                 "bugzilla_component": {
-                    "url": url,
+                    "id": int,
                     "name": string,
                     "parent_component": null,
                     "subcomponents": [
@@ -1023,7 +1023,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
 
             [
                 {
-                    "url": url,
+                    "id": int,
                     "release": {
                         "release_id": string,
                         "active": bool
@@ -1390,7 +1390,7 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
                 "previous": url,
                 "results": [
                     {
-                        "url": url,
+                        "id": int,
                         "name: string,
                         "parent_component": string,
                         "subcomponents": [
@@ -1414,7 +1414,7 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "parent_component": string,
                 "subcomponents": [
@@ -1446,7 +1446,7 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "parent_component": string,
                 "subcomponents": [
@@ -1538,7 +1538,7 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
         __Response__:
 
             {
-                "url": url,
+                "id": int,
                 "name": string,
                 "parent_component": string,
                 "subcomponents": [


### PR DESCRIPTION
Known issues: still keep the url in nested resource, for instance:
* contact url in release_component and global_component

JIRA: PDC-884