### PR TITLE
Enable continuous integration on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+    - "2.7"
+addons:
+    apt:
+        packages:
+            - uuid-dev
+            - swig
+            - libldap2-dev
+# The sed command is a terrible hack: we can't easily install koji on Ubuntu.
+# PDC does not need it, it is a dependency of kobo. However, PDC does not use
+# any part of kobo that would actively use koji, se we just delete the
+# offending import.
+install:
+    - pip install -r requirements/devel.txt
+    - sed -i -E '/import (koji|rpm)/d' $(python -vc 'import kobo.rpmlib' 2>&1 | grep 'import kobo.rpmlib' | awk '{print$NF}' | sed 's/pyc$/py/')
+script:
+    - make test
+    - make flake8

--- a/Makefile
+++ b/Makefile
@@ -44,21 +44,20 @@ clean: FORCE
 FORCE:
 
 # Check code convention based on flake8
-CHECK_DIRS=pdc setup.py
-EXCLUDE_DIRS=pdc/settings*,static,templates,*migrations*
+CHECK_DIRS=.
 FLAKE8_CONFIG_DIR=tox.ini
 
 flake8:
-	flake8 $(CHECK_DIRS) --exclude $(EXCLUDE_DIRS) --config=$(FLAKE8_CONFIG_DIR)
+	flake8 $(CHECK_DIRS) --config=$(FLAKE8_CONFIG_DIR)
 
 run:
 	python manage.py runserver 0.0.0.0:8000
 
 test:
-	python manage.py test pdc contrib
+	python manage.py test --settings pdc.settings_test
 
 cover_test:
-	coverage run --parallel-mode --source=pdc,contrib manage.py test pdc contrib
+	coverage run --parallel-mode manage.py test --settings pdc.settings_test
 	coverage combine
 	coverage html --rcfile=tox.ini
 

--- a/pdc/settings_test.py
+++ b/pdc/settings_test.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+"""
+Extra Django settings for test environment of pdc project.
+"""
+
+from settings import *
+
+
+# Database settings
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'test.sqlite3',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+# disable PERMISSION while testing
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'pdc.apps.auth.authentication.TokenAuthenticationWithChangeSet',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+
+#    'DEFAULT_PERMISSION_CLASSES': [
+#        'rest_framework.permissions.DjangoModelPermissions'
+#    ],
+
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+
+    'PAGINATE_BY': 20,
+
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'pdc.apps.common.renderers.ReadOnlyBrowsableAPIRenderer',
+    ),
+
+    'EXCEPTION_HANDLER': 'pdc.apps.common.handlers.exception_handler'
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
-exclude = *.pyc,*.py~,*.in,*.spec,*.sh,*.rst
+exclude = pdc/settings*,static,docs,templates,*migrations*,*.pyc,*.py~,*.in,*.spec,*.sh,*.rst
 filename = *.py
 ignore = E501,E402,E221
 


### PR DESCRIPTION
After every pull requests, tests will be executed and the results
displayed in GitHub interface. We could drop this after we integrate
with our Jenkins instance, or keep using Travis instead.