### PR TITLE
Add id to override rpms

### DIFF
--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -88,5 +88,5 @@ class OverrideRPMSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 
     class Meta:
         model = OverrideRPM
-        fields = ('release', 'variant', 'arch', 'srpm_name', 'rpm_name',
+        fields = ('id', 'release', 'variant', 'arch', 'srpm_name', 'rpm_name',
                   'rpm_arch', 'include', 'comment', 'do_not_delete')

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -509,7 +509,7 @@ class ComposeUpdateTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertNumChanges([])
 
 
-class OverridesRPMAPITestCase(APITestCase):
+class OverridesRPMAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [
         'pdc/apps/release/fixtures/tests/release.json',
         'pdc/apps/compose/fixtures/tests/compose_overriderpm.json',
@@ -536,13 +536,10 @@ class OverridesRPMAPITestCase(APITestCase):
         self.assertEqual(response.data['count'], 0)
 
     def test_delete_existing(self):
-        response = self.client.delete(reverse('overridesrpm-list'),
-                                      {'release': 'release-1.0',
-                                       'variant': 'Server', 'arch': 'x86_64',
-                                       'rpm_name': 'bash-doc', 'rpm_arch': 'x86_64'})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, self.override_rpm)
+        response = self.client.delete(reverse('overridesrpm-detail', args=[1]))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(models.OverrideRPM.objects.count(), 0)
+        self.assertNumChanges([1])
 
     def test_delete_wrong_data(self):
         response = self.client.delete(reverse('overridesrpm-list'),

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -517,7 +517,7 @@ class OverridesRPMAPITestCase(APITestCase):
 
     def setUp(self):
         self.release = release_models.Release.objects.get(release_id='release-1.0')
-        self.override_rpm = {'release': 'release-1.0', 'variant': 'Server', 'arch': 'x86_64',
+        self.override_rpm = {'id': 1, 'release': 'release-1.0', 'variant': 'Server', 'arch': 'x86_64',
                              'srpm_name': 'bash', 'rpm_name': 'bash-doc', 'rpm_arch': 'x86_64',
                              'include': False, 'comment': '', 'do_not_delete': False}
         self.do_not_delete_orpm = {'release': 'release-1.0', 'variant': 'Server', 'arch': 'x86_64',
@@ -603,9 +603,11 @@ class OverridesRPMAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_clear_force(self):
-        models.OverrideRPM.objects.create(release=self.release, variant="Server", arch="x86_64",
-                                          rpm_name="bash-doc", rpm_arch="src", include=True,
-                                          do_not_delete=True, srpm_name="bash")
+        override = models.OverrideRPM.objects.create(release=self.release, variant="Server",
+                                                     arch="x86_64", rpm_name="bash-doc",
+                                                     rpm_arch="src", include=True,
+                                                     do_not_delete=True, srpm_name="bash")
+        self.do_not_delete_orpm['id'] = override.pk
 
         response = self.client.delete(reverse('overridesrpm-list'), {'release': 'release-1.0', 'force': True})
         self.assertEqual(models.OverrideRPM.objects.count(), 0)

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -29,7 +29,8 @@ from pdc.apps.common.models import Arch
 from pdc.apps.common.hacks import bool_from_native, convert_str_to_bool, as_dict
 from pdc.apps.common.viewsets import (ChangeSetCreateModelMixin,
                                       StrictQueryParamMixin,
-                                      NoEmptyPatchMixin)
+                                      NoEmptyPatchMixin,
+                                      ChangeSetDestroyModelMixin)
 from pdc.apps.release.models import Release
 from .models import (Compose, VariantArch, Variant, ComposeRPM, OverrideRPM,
                      ComposeImage, ComposeRPMMapping, ComposeAcceptanceTestingState)
@@ -840,6 +841,7 @@ class ComposeImportImagesView(StrictQueryParamMixin, viewsets.GenericViewSet):
 class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                                  mixins.ListModelMixin,
                                  ChangeSetCreateModelMixin,
+                                 ChangeSetDestroyModelMixin,
                                  viewsets.GenericViewSet):
     """
     Create, search or delete RPM overrides for specific release. The release is
@@ -956,6 +958,16 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
             }
         """
         return super(ReleaseOverridesRPMViewSet, self).list(*args, **kwargs)
+
+    def destroy(self, *args, **kwargs):
+        """
+        Delete a particular override.
+
+        __Method__: DELETE
+
+        __URL__: `/overrides/rpm/{id}/`
+        """
+        return super(ReleaseOverridesRPMViewSet, self).destroy(*args, **kwargs)
 
     def bulk_destroy(self, *args, **kwargs):
         """

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -871,7 +871,7 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
             }
 
         __Response__:
-        Same as input data, optional fields are always present.
+        Same as input data, optional fields are always present and `id` is added.
 
         __Example__:
 
@@ -880,15 +880,16 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                              "rpm_name": "bash-doc", "rpm_arch": "src", "include": true, \\
                              "release": "release-1.0"}'
             {
-                 "release": "release-1.0",
-                 "variant": "Client",
-                 "arch": "x86_64",
-                 "srpm_name": "bash",
-                 "rpm_name": "bash-doc",
-                 "rpm_arch": "src",
-                 "include": true,
-                 "comment": "",
-                 "do_not_delete": false
+                "id": 1,
+                "release": "release-1.0",
+                "variant": "Client",
+                "arch": "x86_64",
+                "srpm_name": "bash",
+                "rpm_name": "bash-doc",
+                "rpm_arch": "src",
+                "include": true,
+                "comment": "",
+                "do_not_delete": false
             }
         """
         return super(ReleaseOverridesRPMViewSet, self).create(*args, **kwargs)
@@ -918,6 +919,7 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                 "previous": url,
                 "results": [
                     {
+                        "id":               int,
                         "release":          string,
                         "variant":          string,
                         "arch":             string,
@@ -940,6 +942,7 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                 "next": null,
                 "count": 1,
                 "results": [{
+                    "id": 1,
                     "do_not_delete": false,
                     "release": "release-1.0",
                     "variant": "Client",


### PR DESCRIPTION
This pull request adds identifier to override rpms. This allows easier deleting.

Fixes PDC-683 and PDC-885.