### PR TITLE
Fix failing repo test

### DIFF
--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -494,8 +494,10 @@ class RepoBulkTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.post(reverse('repo-list'), args, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.maxDiff = None
+        self.assertRegexpMatches(response.data.get('detail', {}).pop('content_format')[0],
+                                 "'foo' is not allowed value. Use one of .*")
         self.assertEqual(response.data,
-                         {'detail': {'content_format': ["'foo' is not allowed value. Use one of 'rpm', 'iso', 'kickstart', 'comps'."]},
+                         {'detail': {},
                           'invalid_data': {'release_id': 'release-1.0',
                                            'variant_uid': 'Server',
                                            'arch': 'x86_64',


### PR DESCRIPTION
After docker was added as a content_format, the tests were not passing.
This patch updates the test so that it no longer expects a specific list
of possible values but only verifies that the error message has some
options.