### PR TITLE
Update documentation to reflect newer productmd

### DIFF
--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -431,10 +431,10 @@ class ComposeViewSet(StrictQueryParamMixin,
     def filter_queryset(self, qs):
         """
         If the viewset instance has attribute `order_queryset` set to True,
-        this method returns a list of composes ordered by version. Otherwise it
-        will return an unsorted queryset. (It is not possible to sort
-        unconditionally as get_object() will at some point call this method and
-        fail unless it receives a QuerySet instance.)
+        this method returns a list of composes ordered according to *productmd*
+        library. Otherwise it will return an unsorted queryset. (It is not
+        possible to sort unconditionally as get_object() will at some point
+        call this method and fail unless it receives a QuerySet instance.)
         """
         qs = super(ComposeViewSet, self).filter_queryset(qs)
         if getattr(self, 'order_queryset', False):
@@ -470,7 +470,7 @@ class ComposeViewSet(StrictQueryParamMixin,
         """
         Get a list of all composes. The composes are ordered first by the
         release for which they were build (by their short and version).
-        Composes in the same release are ordered by date, respin and type.
+        Composes in the same release are ordered by date, type and respin.
 
         __Method__: GET
 
@@ -1129,8 +1129,8 @@ class FindComposeWithOlderPackageViewSet(StrictQueryParamMixin,
         version of the package.
 
         The ordering of composes is performed by the *productmd* library. It
-        first compares compose date, then respin and lastly compose type
-        (`test` < `nightly` < `production`).
+        first compares compose date, then compose type (`test` < `nightly` <
+        `production`) and lastly respin.
 
         `to_dict` is optional parameter, accepted values (True, 'true', 't', 'True', '1'),
         or (False, 'false', 'f', 'False', '0'). If it is provided, and the value is True,

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -890,7 +890,9 @@ class ReleaseRPMMappingViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_for_more_compose(self):
-        # TODO this test will become invalid once proper compose ordering is implemented
+        # There is compose-1 with some rpms, and newer ComposeWithNoRPMs with
+        # no rpms. The view grabs the newest mapping, finds there is nothing to
+        # show as mapping and returns 404.
         release = models.Release.objects.get(release_id='release-1.0')
         compose_models.Compose.objects.create(
             release=release,

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -471,7 +471,7 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
                 } OR null
             }
 
-        The list of composes is ordered by their date, respin and type (even
+        The list of composes is ordered by their date, type and respin (even
         though those fields are not directly visible here).
         """
         return super(ReleaseViewSet, self).retrieve(*args, **kwargs)
@@ -527,8 +527,8 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
                 ]
             }
 
-        The list of composes for each release is ordered by their date, respin
-        and type (even though those fields are not directly visible here).
+        The list of composes for each release is ordered by their date, type,
+        and respin (even though those fields are not directly visible here).
 
         The releases themselves are ordered by short and version.
         """


### PR DESCRIPTION
Since we now depend on (currently unreleased) productmd, we need to
update some parts of the code.

This patch updates all mentions of compose ordering in documentation as
well a comment in a test in release app. The test continues to work, the
comment is updated to better explain what is going on.

The remaining parts where productmd is used were all updated before the
open-sourcing. These are release/compose/rpms/image import and exporting
rpm manifest.

There are no code changes, just documentation and comments.