### PR TITLE
Create test coverage report on coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ addons:
 # any part of kobo that would actively use koji, se we just delete the
 # offending import.
 install:
-    - pip install -U pip wheel
+    - pip install -U pip wheel coveralls
     - pip install -r requirements/devel.txt
     - sed -i -E '/import (koji|rpm)/d' $(python -vc 'import kobo.rpmlib' 2>&1 | grep 'import kobo.rpmlib' | awk '{print$NF}' | sed 's/pyc$/py/')
 script:
-    - make test
+    - coverage run --source=contrib,pdc --omit='*tests.py,*/migrations/*,pdc/settings*' manage.py test --settings pdc.settings_test
     - make flake8
+after_success:
+    coveralls
 cache:
     directories:
         - $HOME/.cache/pip


### PR DESCRIPTION
[coveralls.io](https://coveralls.io/github/release-engineering/product-definition-center) is a service for analyzing changes in test code coverage
which is free for open-source projects. This patch uploads coverage
information there so that we can see how it changes.