### PR TITLE
PDC-645 Refactor compose/package

### DIFF
--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -101,6 +101,14 @@ router.register(r'rpc/release/clone',
 router.register(r'rpc/where-to-file-bugs', compose_views.FilterBugzillaProductsAndComponents,
                 base_name='bugzilla')
 
+router.register('rpc/find-compose-by-release-rpm/(?P<release_id>[^/]+)/(?P<rpm_name>[^/]+)',
+                compose_views.FindComposeByReleaseRPMViewSet,
+                base_name='findcomposebyrr')
+
+router.register('rpc/find-latest-compose-by-compose-rpm/(?P<compose_id>[^/]+)/(?P<rpm_name>[^/]+)',
+                compose_views.FindLatestComposeByComposeRPMViewSet,
+                base_name='findlatestcomposebycr')
+
 # register common view sets
 router.register(r'arches', common_views.ArchViewSet)
 router.register(r'sigkeys', common_views.SigKeyViewSet)


### PR DESCRIPTION
Add 2 new end points to take old compose/package
endpoint function.
One is  for a given release and srpm_name list all
composes that contain the package (and include its version).
Another is given a compose _C_ and a package, find the
latest compose older than _C_ which contains a
different version of the package.
Keep the old endpoint same for a while to don't break
existing scripts.