### PR TITLE
Explicitly raise an error when updating release component with unknow…

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -370,8 +370,11 @@ class ReleaseComponentSerializer(DynamicFieldsSerializerMixin,
         return ret
 
     def to_internal_value(self, data):
-        # For Update request, restore release and global_component for unique validation.
+        # Raise error explictly when release and global_component are given.
         if self.instance:
+            allowed_keys = self.get_allowed_keys() - set(['release', 'global_component'])
+            extra_fields = set(data.keys()) - allowed_keys
+            self.maybe_raise_error(extra_fields)
             data['release'] = self.instance.release
             data['global_component'] = self.instance.global_component
         return super(ReleaseComponentSerializer, self).to_internal_value(data)

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -946,7 +946,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_update_release_component(self):
         url = reverse('releasecomponent-detail', kwargs={'pk': 1})
-        data = {'release': {'release_id': 'release-1.0', "active": True}, 'global_component': 'python', 'name': 'python26'}
+        data = {'name': 'python26'}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         del response.data['dist_git_web_url']
@@ -957,14 +957,15 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         del response.data['bugzilla_component']
         del response.data['brew_package']
         del response.data['type']
+        del response.data['release']
+        del response.data['global_component']
         data.update({'active': True})
         self.assertEqual(response.data, data)
         self.assertNumChanges([1])
 
     def test_update_release_component_extra_fields(self):
         url = reverse('releasecomponent-detail', kwargs={'pk': 1})
-        data = {'release': {'release_id': 'release-1.0', "active": True},
-                'global_component': 'python', 'name': 'python26', 'foo': 'bar'}
+        data = {'name': 'python26', 'foo': 'bar'}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get('detail'), 'Unknown fields: "foo".')


### PR DESCRIPTION
Explicitly raise an error when updating release component with unknown fields.

Params like `release` and `global_component` will not pass cliently now.