### PR TITLE
Log exception when 503 is returned

### DIFF
--- a/pdc/apps/common/handlers.py
+++ b/pdc/apps/common/handlers.py
@@ -9,6 +9,8 @@ from django.core import exceptions
 from django.conf import settings
 from rest_framework import views, status
 from rest_framework.response import Response
+import sys
+import logging
 
 
 def exception_handler(exc, context):
@@ -54,6 +56,8 @@ def exception_handler(exc, context):
                                        'unable to complete your request.'},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         else:
+            logger = logging.getLogger(__name__)
+            logger.error('Unhandled exception', exc_info=sys.exc_info())
             return Response({'detail': 'The server encountered an internal '
                                        'error or misconfiguration and was '
                                        'unable to complete your request.'},


### PR DESCRIPTION
This should help with troubleshooting problems on devel or qa servers as
the traceback will be in server error log.

There is a change in bulk ops test suite. Some of the tests were
actually wrong and raised an exception for a wrong reason. All exception
logging in those tests is silenced.

This can help development since if there is an unhandled exception
causing 503, the tests now show a traceback of the error instead of just
the failed assertion. There is no change when looking at the bad page in
browser.