### PR TITLE
Fix internal server error on OPTIONS requests

### DIFF
--- a/contrib/bulk_operations/metadata.py
+++ b/contrib/bulk_operations/metadata.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+"""
+Use the provided metadata generator if you wish to support OPTIONS requests on
+list url of resources that support bulk operations. The only difference from
+the generator provided by REST Framework is that it does not try to check
+object permissions when the request would be bulk update.
+
+To use the class, add this to your settings:
+
+    REST_FRAMEWORK = {
+        'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.BulkMetadata'
+    }
+"""
+
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from rest_framework import exceptions
+from rest_framework import metadata
+from rest_framework.request import clone_request
+
+
+class BulkMetadata(metadata.SimpleMetadata):
+    """
+    Simple wrapper around `SimpleMetadata` provided by REST Framework. This
+    class can handle views supporting bulk operations by not checking object
+    permissions on list URL.
+    """
+
+    def determine_actions(self, request, view):
+        """
+        For generic class based views we return information about the fields
+        that are accepted for 'PUT' and 'POST' methods.
+
+        This method expects that `get_object` may actually fail and gracefully
+        handles it.
+
+        Most of the code in this method is copied from the parent class.
+        """
+        actions = {}
+        for method in set(['PUT', 'POST']) & set(view.allowed_methods):
+            view.request = clone_request(request, method)
+            try:
+                # Test global permissions
+                if hasattr(view, 'check_permissions'):
+                    view.check_permissions(view.request)
+                # Test object permissions. This will fail on list url for
+                # resources supporting bulk operations. In such case
+                # permissions are not checked.
+                if method == 'PUT' and hasattr(view, 'get_object'):
+                    try:
+                        view.get_object()
+                    except AssertionError:
+                        pass
+            except (exceptions.APIException, PermissionDenied, Http404):
+                pass
+            else:
+                # If user has appropriate permissions for the view, include
+                # appropriate metadata about the fields that should be supplied.
+                serializer = view.get_serializer()
+                actions[method] = self.get_serializer_info(serializer)
+            finally:
+                view.request = request
+
+        return actions

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -906,6 +906,10 @@ class ReleaseRPMMappingViewSetTestCase(APITestCase):
                                    args=['release-1.0', 'ponies']))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_options_on_list_url(self):
+        response = self.client.options(reverse('release-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 class ReleaseUpdateRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [

--- a/pdc/settings.py
+++ b/pdc/settings.py
@@ -76,6 +76,8 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissions'
     ],
 
+    'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.SimpleMetadata',
+
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
 
     'DEFAULT_RENDERER_CLASSES': (

--- a/pdc/settings_local.py.dist
+++ b/pdc/settings_local.py.dist
@@ -39,6 +39,8 @@
 #
 #         'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
 #
+#         'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.BulkMetadata',
+#
 #         'DEFAULT_RENDERER_CLASSES': (
 #             'rest_framework.renderers.JSONRenderer',
 #             'pdc.apps.common.renderers.ReadOnlyBrowsableAPIRenderer',

--- a/pdc/settings_test.py
+++ b/pdc/settings_test.py
@@ -35,6 +35,8 @@ REST_FRAMEWORK = {
 
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
 
+    'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.BulkMetadata',
+
     'PAGINATE_BY': 20,
 
     'DEFAULT_RENDERER_CLASSES': (


### PR DESCRIPTION
The metadata generator assumed that when a view responds to a PUT
request, it must be possible to call `get_object` on it to test object
permissions. This is however not the case with bulk operations, which
add PUT to list url. An unhandled AssertionError was raised in that
case.

This patch provides a custom BulkMetadata generator, which is pretty
much the same as the one provided by REST Framework, only it is aware
of the bulk operations.

The settings need to be updated in order for the generator to be used.
All settings files in this repository are updated, but anyone using
settings_local.py need to modify it accordingly.