### PR TITLE
Report error on creating release component for missing release

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -19,7 +19,6 @@ from pdc.apps.contact.serializers import RoleContactSerializer
 from pdc.apps.common.serializers import DynamicFieldsSerializerMixin, LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.fields import ChoiceSlugField
 from pdc.apps.release.models import Release
-from pdc.apps.release.serializers import ReleaseSerializer
 from .models import (GlobalComponent,
                      RoleContact,
                      ReleaseComponent,
@@ -300,20 +299,17 @@ class BugzillaComponentSerializer(DynamicFieldsSerializerMixin,
         fields = ('id', 'name', 'parent_component', 'subcomponents')
 
 
-class ReleaseField(serializers.Field):
-    def to_representation(self, value):
-        ret = {}
-        serializer = ReleaseSerializer(value)
-        ret.setdefault('release_id', serializer.data['release_id'])
-        ret.setdefault('active', serializer.data['active'])
-        return ret
+class ReleaseField(serializers.SlugRelatedField):
+    def __init__(self, **kwargs):
+        super(ReleaseField, self).__init__(slug_field='release_id',
+                                           queryset=Release.objects.all(),
+                                           **kwargs)
 
-    def to_internal_value(self, data):
-        try:
-            rel = Release.objects.get(release_id=data)
-        except Release.DoesNotExist:
-            raise Exception("Release with ID %s doesn't exist" % data)
-        return rel
+    def to_representation(self, value):
+        return {
+            'release_id': value.release_id,
+            'active': value.active
+        }
 
 
 class ReleaseComponentSerializer(DynamicFieldsSerializerMixin,

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -841,6 +841,17 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])
 
+    def test_create_release_component_for_non_existing_release(self):
+        url = reverse('releasecomponent-list')
+        data = {'release': 'hello-1.0',
+                'global_component': 'python',
+                'name': 'python26',
+                'brew_package': 'python-pdc'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'release': ['Object with release_id=hello-1.0 does not exist.']})
+        self.assertNumChanges([])
+
     def test_create_release_component_with_type(self):
         url = reverse('releasecomponent-list')
         data = {'release': 'release-1.0', 'global_component': 'python', 'name': 'python26',


### PR DESCRIPTION
The ReleaseField is refactored to be based on SlugRelatedField which
provides error handling consistent with rest of the API.

There is now a test for creating a release component on a non-existing
release.

JIRA: PDC-868