### PR TITLE
Don't delete group type with a group

### DIFF
--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -263,7 +263,8 @@ class GroupType(models.Model):
 
 
 class ReleaseComponentGroup(models.Model):
-    group_type = models.ForeignKey(GroupType, related_name='release_component_groups')
+    group_type = models.ForeignKey(GroupType, related_name='release_component_groups',
+                                   on_delete=models.PROTECT)
     release = models.ForeignKey(Release, related_name='release_component_groups')
     description = models.CharField(max_length=200)
     components = models.ManyToManyField(ReleaseComponent, related_name='release_component_groups', blank=True)

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2219,6 +2219,12 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertNumChanges([1])
 
+    def test_delete_type_with_existing_group(self):
+        url = reverse('componentgrouptype-detail', args=[1])
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
 
 class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [


### PR DESCRIPTION
When there is a group of certain type, make it impossible to delete the
type. The original behaviour was incorrect: the cascading deletes would
not be logged in changeset. Disabling the cascade is both easier and
more practical for the user as deleting the type should be rare.

JIRA: PDC-875