### PR TITLE
Fix issue that create component-groups without release components

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -471,10 +471,10 @@ class GroupSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 
     def validate(self, value):
         if not self.instance or not self.partial:
-            components = value.get('components')
+            components = value.get('components', [])
             release = value.get('release')
         elif 'components' in value:
-            components = value.get('components')
+            components = value.get('components', [])
             release = self.instance.release
         else:
             components = self.instance.components.all()

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2162,6 +2162,13 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNumChanges([1])
 
+    def test_create_group_without_component(self):
+        url = reverse('componentgroup-list')
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1])
+
     def test_create_group_with_non_existed_release_component(self):
         url = reverse('componentgroup-list')
         data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd', 'components': [9999]}


### PR DESCRIPTION
Without release components provided, the default components is None
which can't be iterated. Update it to empty list.

JIRA: PDC-872