### PR TITLE
PDC-639 Track rpms in releases and display composes' information in rpm

### DIFF
--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -121,15 +121,18 @@ class VersionFinderTestCase(APITestCase):
             {'compose': u'compose-1', 'packages': [
                 {'name': u'bash', 'version': u'1.2.3', 'epoch': 0, 'release': u'4.b1',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': u'bash-0:1.2.3-4.b1.src',
-                 'filename': 'bash-1.2.3-4.b1.x86_64.rpm'}]},
+                 'filename': 'bash-1.2.3-4.b1.x86_64.rpm', 'id': 1,
+                 'linked_composes': [u'compose-1', u'compose-2'], 'linked_releases': []}]},
             {'compose': u'compose-2', 'packages': [
                 {'name': u'bash', 'version': u'1.2.3', 'epoch': 0, 'release': u'4.b1',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': u'bash-0:1.2.3-4.b1.src',
-                 'filename': 'bash-1.2.3-4.b1.x86_64.rpm'}]},
+                 'filename': 'bash-1.2.3-4.b1.x86_64.rpm', 'id': 1,
+                 'linked_composes': [u'compose-1', u'compose-2'], 'linked_releases': []}]},
             {'compose': u'compose-3', 'packages': [
                 {'name': u'bash', 'version': u'5.6.7', 'epoch': 0, 'release': u'8',
                  'arch': u'x86_64', 'srpm_name': u'bash', 'srpm_nevra': None,
-                 'filename': 'bash-5.6.7-8.x86_64.rpm'}]}
+                 'filename': 'bash-5.6.7-8.x86_64.rpm', 'id': 2,
+                 'linked_composes': [u'compose-3'], 'linked_releases': []}]}
         ]
         self.assertEqual(response.data, expected)
 

--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -23,11 +23,12 @@ class RPMFilter(django_filters.FilterSet):
     filename    = MultiValueFilter()
     compose     = MultiValueFilter(name='composerpm__variant_arch__variant__compose__compose_id',
                                    distinct=True)
+    linked_release = MultiValueFilter(name='linked_releases__release_id', distinct=True)
 
     class Meta:
         model = models.RPM
         fields = ('name', 'version', 'epoch', 'release', 'arch', 'srpm_name',
-                  'srpm_nevra', 'compose', 'filename')
+                  'srpm_nevra', 'compose', 'filename', 'linked_release')
 
 
 class ImageFilter(django_filters.FilterSet):

--- a/pdc/apps/package/fixtures/test/rpm.json
+++ b/pdc/apps/package/fixtures/test/rpm.json
@@ -35,7 +35,7 @@
       "epoch": 0,
       "version": "1.2.3",
       "release": "4",
-      "arch": "x86_64",
+      "arch": "src",
       "srpm_name": "bash",
       "srpm_nevra": null,
       "filename": "bash-other-1.2.3-4.x86_64.rpm"

--- a/pdc/apps/package/migrations/0004_rpm_linked_releases.py
+++ b/pdc/apps/package/migrations/0004_rpm_linked_releases.py
@@ -13,13 +13,13 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('release', '0002_auto_20150512_0719'),
-        ('package', '0002_auto_20150512_0714'),
+        ('package', '0003_buildimage_releases'),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='buildimage',
-            name='releases',
-            field=models.ManyToManyField(to='release.Release'),
+            model_name='rpm',
+            name='linked_releases',
+            field=models.ManyToManyField(related_name='linked_rpms', to='release.Release'),
         ),
     ]

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -11,9 +11,7 @@ from . import serializers
 from . import filters
 
 
-class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
-                 mixins.ListModelMixin,
-                 viewsets.GenericViewSet):
+class RPMViewSet(pdc_viewsets.PDCModelViewSet):
     """
     API endpoint that allows RPMs to be viewed.
     """
@@ -37,6 +35,7 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
           * `srpm_name`
           * `srpm_nevra`
           * `compose`
+          * `linked_release`
 
         __Response__:
 
@@ -47,6 +46,7 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
                 "previous": url,
                 "results": [
                     {
+                        "id": int,
                         "name": string,
                         "version": string,
                         "epoch": int,
@@ -54,13 +54,128 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
                         "arch": string,
                         "srpm_name": string,
                         "srpm_nevra": string,
-                        "filename": string
+                        "filename": string,
+                        "linked_releases": [string, ....],
+                        "linked_composes": [string, ....]
                     },
                     ...
                 ]
             }
         """
         return super(RPMViewSet, self).list(*args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        """
+        __Method__:
+        POST
+
+        __URL__:
+        `/rpms/`
+
+        __Data__:
+
+            {
+                "name": string,
+                "version": string,
+                "epoch": int,
+                "release": string,
+                "arch": string,
+                "srpm_name": string,
+                "srpm_nevra": string, srpm_nevra should be empty if and only if arch is src.
+                "filename": string, # optional
+                "linked_releases": [string, ....] # optional
+            }
+
+
+        __Response__:
+
+            {
+                "id": integer,
+                "name": string,
+                "version": string,
+                "epoch": int,
+                "release": string,
+                "arch": string,
+                "srpm_name": string,
+                "srpm_nevra": string,
+                "filename": string,
+                "linked_releases": [string, ....],
+                "linked_composes": []
+            }
+        """
+        return super(RPMViewSet, self).create(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        __Method__:
+        GET
+
+        __URL__:
+        `/rpms/{instance_pk}`
+
+        __Response__:
+
+            {
+                "id": integer,
+                "name": string,
+                "version": string,
+                "epoch": int,
+                "release": string,
+                "arch": string,
+                "srpm_name": string,
+                "srpm_nevra": string,
+                "filename": string,
+                "linked_releases": [string, ....],
+                "linked_composes": [string, ....]
+            }
+        """
+        return super(RPMViewSet, self).retrieve(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """
+        __Method__:
+
+        PUT: for full fields update
+
+            {
+                "name": string,
+                "version": string,
+                "epoch": int,
+                "release": string,
+                "arch": string,
+                "srpm_name": string,
+                "srpm_nevra": string, srpm_nevra should be empty if and only if arch is src.
+                "filename": string,
+                "linked_releases": [string, ....] # optional
+            }
+
+        PATCH: for partial update
+
+            # so you can give one or more fields in ['name', 'version', 'epoch', 'release', 'arch',
+            #                                        'srpm_name', 'srpm_nevra', 'filename', 'linked_releases']
+            # to do the update
+
+
+        __URL__:
+        /rpms/{instance_pk}
+
+        __Response__:
+
+            {
+                "id": integer,
+                "name": string,
+                "version": string,
+                "epoch": int,
+                "release": string,
+                "arch": string,
+                "srpm_name": string,
+                "srpm_nevra": string,
+                "filename": string,
+                "linked_releases": [string, ....],
+                "linked_composes": [string, ....]
+            }
+        """
+        return super(RPMViewSet, self).update(request, *args, **kwargs)
 
 
 class ImageViewSet(pdc_viewsets.StrictQueryParamMixin,

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -890,7 +890,7 @@ class ReleaseRPMMappingView(StrictQueryParamMixin, viewsets.GenericViewSet):
         only include variants and architectures listed for the release.
 
         The used overrides come from the release specified in the URL, not the
-        one for which the compose was orignally built for.
+        one for which the compose was originally built for.
 
         Following cases result in response of `404 NOT FOUND`:
 


### PR DESCRIPTION
1. Add create, update, bulk update methods for RPM so that user
could assign assign rpms to releases.
2. Display compose information in RPM output.
3. Add id field in RPM output, thus also add retrieve method.