### PR TITLE
Handle bad data for bulk delete

### DIFF
--- a/contrib/bulk_operations/bulk_operations.py
+++ b/contrib/bulk_operations/bulk_operations.py
@@ -87,6 +87,10 @@ def bulk_destroy_impl(self, request, **kwargs):
     if not isinstance(request.data, list):
         return Response(status=status.HTTP_400_BAD_REQUEST,
                         data={'detail': 'Bulk delete needs a list of identifiers.'})
+    for ident in request.data:
+        if not isinstance(ident, basestring) and not isinstance(ident, int):
+            return Response(status=status.HTTP_400_BAD_REQUEST,
+                            data={'detail': '"%s" is not a valid identifier.' % ident})
     self.kwargs.update(kwargs)
     for ident in OrderedDict.fromkeys(request.data):
         self.kwargs[self.lookup_field] = unicode(ident)

--- a/contrib/bulk_operations/tests.py
+++ b/contrib/bulk_operations/tests.py
@@ -178,6 +178,12 @@ class BulkOperationTestCase(unittest.TestCase):
         response = bulk.bulk_update_impl(self.viewset, self.request)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_bulk_delete_with_list_of_dicts(self):
+        self.request.data = [{"hello": "world"}]
+        response = bulk.bulk_destroy_impl(self.viewset, self.request)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('not a valid identifier', response.data.get('detail', ''))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When user tries to bulk delete data with dicts instead of identifiers,
we should report a sensible error instead of crashing the server.

JIRA: PDC-910