### PR TITLE
Make easy understand for ReleaseComponent fields input.

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -440,10 +440,21 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
         return result
 
     def to_internal_value(self, data):
+        if not isinstance(data, dict):
+            raise serializers.ValidationError({'detail': "Input [%s] for ReleaseComponent must be a dict." % data})
+        kwargs = dict()
+        if 'id' in data:
+            kwargs['id'] = data.get('id')
+        else:
+            kwargs['release__release_id'] = data.get('release')
+            kwargs['global_component__name'] = data.get('global_component')
+            kwargs['name'] = data.get('name')
         try:
-            rc = ReleaseComponent.objects.get(id=data)
+            rc = ReleaseComponent.objects.get(**kwargs)
         except ReleaseComponent.DoesNotExist:
             raise serializers.ValidationError({'detail': "ReleaseComponent [%s] doesn't exist" % data})
+        except Exception as ex:
+            raise serializers.ValidationError({'detail': 'Fail to get ReleaseComponent, reason: %s' % str(ex)})
         return rc
 
 

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -443,9 +443,10 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
         if not isinstance(data, dict):
             raise serializers.ValidationError({'detail': "Input [%s] for ReleaseComponent must be a dict." % data})
 
-        if set(['id', 'release', 'global_component', 'name']) <= set(data):
+        if ('id' in data and len(data.keys()) > 1) or \
+                ('release' in data and 'global_component' in data and 'name' in data and len(data.keys()) > 3):
             raise serializers.ValidationError(
-                {'detail': "It's not allowed to provide 'id' and ['release', 'global_component', 'name'] together"})
+                {'detail': "Only accept ['id'] or ['release', 'global_component', 'name']"})
 
         kwargs = dict()
         if 'id' in data:

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -442,6 +442,11 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
     def to_internal_value(self, data):
         if not isinstance(data, dict):
             raise serializers.ValidationError({'detail': "Input [%s] for ReleaseComponent must be a dict." % data})
+
+        if set(['id', 'release', 'global_component', 'name']) <= set(data):
+            raise serializers.ValidationError(
+                {'detail': "It's not allowed to provide 'id' and ['release', 'global_component', 'name'] together"})
+
         kwargs = dict()
         if 'id' in data:
             kwargs['id'] = data.get('id')
@@ -453,8 +458,6 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
             rc = ReleaseComponent.objects.get(**kwargs)
         except ReleaseComponent.DoesNotExist:
             raise serializers.ValidationError({'detail': "ReleaseComponent [%s] doesn't exist" % data})
-        except Exception as ex:
-            raise serializers.ValidationError({'detail': 'Fail to get ReleaseComponent, reason: %s' % str(ex)})
         return rc
 
 

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2182,6 +2182,14 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNumChanges([1])
 
+    def test_create_group_with_components_mix_id_unique_together_fields(self):
+        url = reverse('componentgroup-list')
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{'id': 2, 'release': 'release-1.0', 'global_component': 'python', 'name': 'python27'}]}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
     def test_create_group_with_components_wrong_format(self):
         url = reverse('componentgroup-list')
         data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2198,6 +2198,26 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
+    def test_create_group_with_components_with_wrong_field(self):
+        url = reverse('componentgroup-list')
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{"foo": "bar"}]}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{"iid": 1, "release": "foo"}]}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{"id": 1, "release": "foo"}]}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
     def test_create_group_without_component(self):
         url = reverse('componentgroup-list')
         data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd'}

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2166,12 +2166,29 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_create_group(self):
+    def test_create_group_with_components_id(self):
         url = reverse('componentgroup-list')
-        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd', 'components': [1, 2]}
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{'id': 1}, {'id': 2}]}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNumChanges([1])
+
+    def test_create_group_with_components_unique_together_fields(self):
+        url = reverse('componentgroup-list')
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': [{'release': 'release-1.0', 'global_component': 'python', 'name': 'python27'}]}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1])
+
+    def test_create_group_with_components_wrong_format(self):
+        url = reverse('componentgroup-list')
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd',
+                'components': ['wrong field']}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
 
     def test_create_group_without_component(self):
         url = reverse('componentgroup-list')
@@ -2182,34 +2199,35 @@ class GroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_create_group_with_non_existed_release_component(self):
         url = reverse('componentgroup-list')
-        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd', 'components': [9999]}
+        data = {'group_type': 'type2', 'release': 'release-1.0', 'description': 'dd', 'components': [{'id': 9999}]}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
     def test_create_group_with_different_releases(self):
         url = reverse('componentgroup-list')
-        data = {'group_type': 'type2', 'release': 'release-2.0', 'description': 'dd', 'components': [1, 2]}
+        data = {'group_type': 'type2', 'release': 'release-2.0', 'description': 'dd',
+                'components': [{'id': 1}, {'id': 2}]}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
     def test_update_group(self):
         url = reverse('componentgroup-detail', kwargs={'pk': 1})
-        data = {'group_type': 'type1', 'release': 'release-1.0', 'description': 'dd', 'components': [1]}
+        data = {'group_type': 'type1', 'release': 'release-1.0', 'description': 'dd', 'components': [{'id': 1}]}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('components')[0].get('name'), 'python27')
 
     def test_update_group_with_other_release(self):
         url = reverse('componentgroup-detail', kwargs={'pk': 1})
-        data = {'group_type': 'type1', 'release': 'release-2.0', 'description': 'dd', 'components': [1]}
+        data = {'group_type': 'type1', 'release': 'release-2.0', 'description': 'dd', 'components': [{'id': 1}]}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_partial_update_group(self):
         url = reverse('componentgroup-detail', kwargs={'pk': 1})
-        data = {'components': [1]}
+        data = {'components': [{'id': 1}]}
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('components')[0].get('name'), 'python27')
@@ -2251,7 +2269,7 @@ class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITe
 
     def test_create_relationship(self):
         url = reverse('rcrelationship-list')
-        data = {"from_component": "1", "to_component": "2", "type": "executes"}
+        data = {"from_component": {'id': 1}, "to_component": {'id': 2}, "type": "executes"}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNumChanges([1])
@@ -2262,14 +2280,32 @@ class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITe
 
     def test_create_relationship_with_non_existed_release_component(self):
         url = reverse('rcrelationship-list')
-        data = {"from_component": "1", "to_component": "20000", "type": "executes"}
+        data = {"from_component": {'id': 1}, "to_component": {'id': 20000}, "type": "executes"}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
     def test_create_relationship_with_non_existed_type(self):
         url = reverse('rcrelationship-list')
-        data = {"from_component": "1", "to_component": "2", "type": "fake-type"}
+        data = {"from_component": {'id': 1}, "to_component": {'id': 2}, "type": "fake-type"}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
+    def test_create_relationship_with_unique_together_fields(self):
+        url = reverse('rcrelationship-list')
+        data = {"from_component": {'release': 'release-1.0', 'global_component': 'python', 'name': 'python27'},
+                "to_component": {'release': 'release-1.0', 'global_component': 'MySQL-python', 'name': 'MySQL-python'},
+                "type": "executes"}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1])
+
+    def test_create_group_with_components_wrong_format(self):
+        url = reverse('rcrelationship-list')
+        data = {"from_component": 'wrong field',
+                "to_component": {'release': 'release-1.0', 'global_component': 'MySQL-python', 'name': 'MySQL-python'},
+                "type": "executes"}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
@@ -2311,21 +2347,21 @@ class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITe
     def test_update_relationship(self):
         url = reverse('rcrelationship-detail', kwargs={'pk': 1})
         # 2 name MySQL-python, 3 name java
-        data = {'type': 'executes', "from_component": 2, "to_component": 3}
+        data = {'type': 'executes', "from_component": {'id': 2}, "to_component": {'id': 3}}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('to_component').get('name'), 'java')
 
     def test_update_relationship_with_non_exist_release_component(self):
         url = reverse('rcrelationship-detail', kwargs={'pk': 1})
-        data = {'type': 'executes', "from_component": 2, "to_component": 20}
+        data = {'type': 'executes', "from_component": {'id': 2}, "to_component": {'id': 20}}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_partial_update_relationship_to_component(self):
         url = reverse('rcrelationship-detail', kwargs={'pk': 1})
         # 2 name MySQL-python, 3 name java
-        data = {"to_component": 3}
+        data = {"to_component": {'id': 3}}
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('to_component').get('name'), 'java')
@@ -2333,7 +2369,7 @@ class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITe
     def test_partial_update_relationship_from_component(self):
         url = reverse('rcrelationship-detail', kwargs={'pk': 1})
         # 2 name MySQL-python, 3 name java
-        data = {"from_component": 3}
+        data = {"from_component": {'id': 3}}
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('from_component').get('name'), 'java')

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -1789,7 +1789,8 @@ class GroupViewSet(viewsets.PDCModelViewSet):
 
         __Note__:
 
-          * components: list of release_component id, eg: [1, 2]
+          * components: list of release_components, eg: [{"id": 1}, {"id": 2}] or
+          [{"release": "release-1.0", "global_component": "python", "name": "python27"}]
           * group_type, release and release_components have to be existed before creating Release Component Group
           * It's not allowed to group release_components from different releases
 
@@ -1872,7 +1873,8 @@ class GroupViewSet(viewsets.PDCModelViewSet):
 
         __Note__:
 
-          * components: list of release_component id, eg: [1, 2]
+          * components: list of release_components, eg: [{"id": 1}, {"id": 2}] or
+          [{"release": "release-1.0", "global_component": "python", "name": "python27"}]
 
         __Response__:
 
@@ -1917,16 +1919,16 @@ class ReleaseComponentRelationshipViewSet(viewsets.PDCModelViewSet):
         __Data__:
 
             {
-                "from_component":       id,         # required
-                "type":                 string      # required
-                "to_component":         id,         # required
+                "from_component":       dict,         # required
+                "type":                 string,       # required
+                "to_component":         dict,         # required
             }
 
         __Note__:
 
-          * from_component: release component id of 'from' side
+          * from_component: {"id": 1} or {"release": "release-1.0", "global_component": "python", "name": "python27"}
           * type: relationship type
-          * to_component: release component id of 'to' side
+          * to_component: {"id": 2} or {"release": "release-2.0", "global_component": "python", "name": "python27"}
 
         __Response__:
 
@@ -2025,10 +2027,15 @@ class ReleaseComponentRelationshipViewSet(viewsets.PDCModelViewSet):
         __Data__:
 
             {
-                "from_component":       id,         # required
-                "type":                 string      # required
-                "to_component":         id,         # required
+                "from_component":       dict,         # required
+                "type":                 string,       # required
+                "to_component":         dict,         # required
             }
+
+        __Note__:
+
+          * from_component: {"id": 1} or {"release": "release-1.0", "global_component": "python", "name": "python27"}
+          * to_component: {"id": 2} or {"release": "release-2.0", "global_component": "python", "name": "python27"}
 
         __Response__:
 


### PR DESCRIPTION
It was not friendly only with id for ReleaseComponent, instead provide
two option: one is object id, the other is resource's unique_together
fields. Both of them need to be input as a dict.
Impact endpoints include: component-groups and release-component-relationships

JIRA: PDC-905