### PR TITLE
Fix bulk metadata generator in production

### DIFF
--- a/contrib/bulk_operations/metadata.py
+++ b/contrib/bulk_operations/metadata.py
@@ -53,7 +53,7 @@ class BulkMetadata(metadata.SimpleMetadata):
                 if method == 'PUT' and hasattr(view, 'get_object'):
                     try:
                         view.get_object()
-                    except AssertionError:
+                    except (AssertionError, KeyError):
                         pass
             except (exceptions.APIException, PermissionDenied, Http404):
                 pass


### PR DESCRIPTION
The AssertionError can only be raised in debug mode. On product server,
the assert is skipped and a KeyError is raised instead.