### PR TITLE
Improve error message for wrong relationship type

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -499,7 +499,7 @@ class RCForRelationshipRelatedField(ReleaseComponentRelatedField):
 
 
 class ReleaseComponentRelationshipSerializer(StrictSerializerMixin, serializers.ModelSerializer):
-    type = serializers.SlugRelatedField(
+    type = ChoiceSlugField(
         queryset=ReleaseComponentRelationshipType.objects.all(),
         slug_field='name',
         required=True,


### PR DESCRIPTION
Since the types are not exposed in API currently, we should at least
list them in error message when bad type is given.