### PR TITLE
Add missing field to compose documentation

### DIFF
--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -603,8 +603,8 @@ class ComposeViewSet(StrictQueryParamMixin,
     def partial_update(self, request, *args, **kwargs):
         """
         The only two fields that can be modified by this call are
-        `acceptance_testing` and `linked_releases`. Trying to change anything
-        else will result in 400 BAD REQUEST response.
+        `acceptance_testing`, `linked_releases` and `rtt_tested_architectures`.
+        Trying to change anything else will result in 400 BAD REQUEST response.
 
         __Method__: PATCH
 


### PR DESCRIPTION
The list of updatable fields in a compose was missing
rtt_tested_architectures.

JIRA: PDC-928