### PR TITLE
Add dud as valid content format

### DIFF
--- a/pdc/apps/repository/migrations/0002_auto_20150512_0724.py
+++ b/pdc/apps/repository/migrations/0002_auto_20150512_0724.py
@@ -73,6 +73,10 @@ def create_content_format(apps, schema_editor):
                {
                    'description': 'Docker image content format',
                    'name': 'docker'
+               },
+               {
+                   'description': 'Driver Update Disk',
+                   'name': 'dud'
                }
            ])
 


### PR DESCRIPTION
It stands for Driver Update Disk. Staging and production servers were
updated already, this is only a fix so that if we ever need to recreate
the database from scratch it will automatically created again.

JIRA: PDC-932