### PR TITLE
Create compose-images resource

### DIFF
--- a/pdc/apps/compose/fixtures/tests/compose_composeimage.json
+++ b/pdc/apps/compose/fixtures/tests/compose_composeimage.json
@@ -1,10 +1,18 @@
 [
   {
+    "model": "compose.Path",
+    "pk": 1,
+    "fields": {
+        "path": "path/to/images"
+    }
+  },
+  {
     "model": "compose.ComposeImage",
     "pk": 1,
     "fields": {
         "variant_arch": 1,
-        "image": 1
+        "image": 1,
+        "path": 1
     }
   },
   {
@@ -12,7 +20,8 @@
     "pk": 2,
     "fields": {
         "variant_arch": 1,
-        "image": 2
+        "image": 2,
+        "path": 1
     }
   },
   {
@@ -20,7 +29,8 @@
     "pk": 3,
     "fields": {
         "variant_arch": 1,
-        "image": 3
+        "image": 3,
+        "path": 1
     }
   }
 ]

--- a/pdc/apps/compose/migrations/0004_auto_20150819_0826.py
+++ b/pdc/apps/compose/migrations/0004_auto_20150819_0826.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('compose', '0003_auto_20150610_1338'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='composeimage',
+            name='path',
+            field=models.ForeignKey(to='compose.Path', null=True),
+        ),
+        migrations.AlterField(
+            model_name='path',
+            name='path',
+            field=models.CharField(unique=True, max_length=4096, blank=True),
+        ),
+    ]

--- a/pdc/apps/compose/migrations/0005_auto_20150819_0827.py
+++ b/pdc/apps/compose/migrations/0005_auto_20150819_0827.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def set_empty_path(apps, schema_editor):
+    path, _ = apps.get_model('compose', 'Path').objects.get_or_create(path='')
+    for compose_image in apps.get_model('compose', 'ComposeImage').objects.filter(path=None):
+        compose_image.path = path
+        compose_image.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('compose', '0004_auto_20150819_0826'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_empty_path),
+        migrations.AlterField(
+            model_name='composeimage',
+            name='path',
+            field=models.ForeignKey(to='compose.Path'),
+        ),
+    ]

--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -218,7 +218,7 @@ class Path(models.Model):
     Class representing a path in compose. The same path can be reused in
     multiple places (e.g. in more RPMs).
     """
-    path = models.CharField(max_length=4096, unique=True)
+    path = models.CharField(max_length=4096, unique=True, blank=True)
 
     def __unicode__(self):
         return unicode(self.path)
@@ -499,6 +499,7 @@ class OverrideRPM(models.Model):
 class ComposeImage(models.Model):
     variant_arch        = models.ForeignKey(VariantArch, db_index=True)
     image               = models.ForeignKey("package.Image", db_index=True)
+    path                = models.ForeignKey(Path)
 
     class Meta:
         unique_together = (

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -74,6 +74,7 @@ router.register(r'composes/(?P<compose_id>[^/]+)/rpm-mapping',
                 compose_views.ComposeRPMMappingView,
                 base_name='composerpmmapping')
 router.register(r'compose-rpms', compose_views.ComposeRPMView)
+router.register(r'compose-images', compose_views.ComposeImageView)
 
 router.register(r'rpc/release/import-from-composeinfo',
                 release_views.ReleaseImportView,


### PR DESCRIPTION
This is a resource that works pretty much the same as compose-rpms. It
allows import compose images and getting the same data back.

The old import API is still available, but marked as deprecated.

Since the existing code did not store path for the images (just the
filename), there are two migrations to get to the desired state. The
first migration deletes all ComposeImage objects, the second creates the
new column in database.

The idea is that deploying on the server and running the migrations will
only lose the minimum amount of data. The images themselves will be
preserved, only their connections to composes will need to be imported
again.

JIRA: PDC-911