### PR TITLE
Catch more detail excepton.

### DIFF
--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -19,6 +19,7 @@ from pdc.apps.contact.serializers import RoleContactSerializer
 from pdc.apps.common.serializers import DynamicFieldsSerializerMixin, LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.fields import ChoiceSlugField
 from pdc.apps.release.models import Release
+from pdc.apps.common.hacks import convert_str_to_int
 from .models import (GlobalComponent,
                      RoleContact,
                      ReleaseComponent,
@@ -449,7 +450,7 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
 
         kwargs = dict()
         if 'id' in data:
-            kwargs['id'] = data.get('id')
+            kwargs['id'] = convert_str_to_int(data.get('id'))
         else:
             kwargs['release__release_id'] = data.get('release')
             kwargs['global_component__name'] = data.get('global_component')
@@ -458,8 +459,6 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
             rc = ReleaseComponent.objects.get(**kwargs)
         except ReleaseComponent.DoesNotExist:
             raise serializers.ValidationError({'detail': "ReleaseComponent [%s] doesn't exist" % data})
-        except ValueError as ex:
-            raise serializers.ValidationError({'detail': "%s is incorrect, reason: %s" % (data, str(ex))})
         return rc
 
 

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -458,6 +458,8 @@ class ReleaseComponentRelatedField(serializers.RelatedField):
             rc = ReleaseComponent.objects.get(**kwargs)
         except ReleaseComponent.DoesNotExist:
             raise serializers.ValidationError({'detail': "ReleaseComponent [%s] doesn't exist" % data})
+        except ValueError as ex:
+            raise serializers.ValidationError({'detail': "%s is incorrect, reason: %s" % (data, str(ex))})
         return rc
 
 

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -2306,6 +2306,13 @@ class ReleaseComponentRelationshipRESTTestCase(TestCaseWithChangeSetMixin, APITe
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 3)
 
+    def test_create_relationship_with_non_integer_id(self):
+        url = reverse('rcrelationship-list')
+        data = {"from_component": {'id': 'ab'}, "to_component": {'id': 'abc'}, "type": "executes"}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
     def test_create_relationship_with_non_existed_release_component(self):
         url = reverse('rcrelationship-list')
         data = {"from_component": {'id': 1}, "to_component": {'id': 20000}, "type": "executes"}


### PR DESCRIPTION
Catch ValueError exception for release component input.
It's not friendly to tell user internal error but log into
server's error log file without this exception block.

JIRA: PDC-905