### PR TITLE
Display all routes in API root

### DIFF
--- a/pdc/apps/utils/tests.py
+++ b/pdc/apps/utils/tests.py
@@ -6,8 +6,8 @@
 from datetime import datetime
 import random
 
-from django.test import TestCase
 from django.core.urlresolvers import reverse
+from django.test import TestCase
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -34,8 +34,19 @@ class EpochFormatTest(TestCase):
             self.assertEqual(ts, total_seconds)
 
 
-class SortedAPIRootTest(APITestCase):
-    def test_get_api_root(self):
+class APIRootTestCase(APITestCase):
+    def test_api_root_is_sorted(self):
         rsp = self.client.get(reverse('api-root'))
         self.assertEqual(rsp.status_code, status.HTTP_200_OK)
         self.assertEqual(rsp.data.keys(), sorted(rsp.data.keys()))
+
+    def test_root_includes_release_component_contacts(self):
+        response = self.client.get(reverse('api-root'))
+        self.assertIn('release-components/{instance_pk}/contacts', response.data)
+
+    def test_root_includes_release_rpm_mapping(self):
+        response = self.client.get(reverse('api-root'))
+        key = 'releases/{release_id}/rpm-mapping'
+        self.assertIn(key, response.data)
+        self.assertEqual(response.data[key],
+                         'http://testserver/rest_api/v1/releases/%7Brelease_id%7D/rpm-mapping/%7Bpackage%7D/')

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -16,7 +16,7 @@ from pdc.apps.package import views as rpm_views
 from pdc.apps.utils import SortedRouter
 
 
-router = SortedRouter.PDCrouter()
+router = SortedRouter.PDCRouter()
 
 # register api token auth view
 router.register(r'auth/token', pdc_auth_views.TokenViewSet, base_name='token')


### PR DESCRIPTION
This patch modifies the router to include all resources in the API root.
It tries various options how to generate an URL. Currently it works with
all existing resources. If in the future we include a resource it can
not generate a url for, the resource will be listed with null url.

There is a bit of a heuristic to avoid generating urls that will lead to
a server crash.

A test is included that tests more special urls.

JIRA: PDC-913