### PR TITLE
Split compose migrations in two

### DIFF
--- a/pdc/apps/compose/migrations/0005_auto_20150819_0827.py
+++ b/pdc/apps/compose/migrations/0005_auto_20150819_0827.py
@@ -24,9 +24,4 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(set_empty_path),
-        migrations.AlterField(
-            model_name='composeimage',
-            name='path',
-            field=models.ForeignKey(to='compose.Path'),
-        ),
     ]

--- a/pdc/apps/compose/migrations/0006_auto_20150821_0616.py
+++ b/pdc/apps/compose/migrations/0006_auto_20150821_0616.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('compose', '0005_auto_20150819_0827'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='composeimage',
+            name='path',
+            field=models.ForeignKey(to='compose.Path'),
+        ),
+    ]


### PR DESCRIPTION
PostgreSQL does not like a migration to modify data and change the
schema at the same time, so use first migration to fill in missing paths
for compose images and second migration to make the field non-nullable.