### PR TITLE
Make sigkey key_id editable

### DIFF
--- a/pdc/apps/common/serializers.py
+++ b/pdc/apps/common/serializers.py
@@ -75,11 +75,6 @@ class ArchSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 
 class SigKeySerializer(StrictSerializerMixin,
                        serializers.HyperlinkedModelSerializer):
-    key_id = serializers.CharField(read_only=True)
-
     class Meta:
         model = SigKey
-        fields = ('url', 'name', 'key_id', 'description')
-        extra_kwargs = {
-            'url': {'lookup_field': 'key_id'}
-        }
+        fields = ('name', 'key_id', 'description')

--- a/pdc/apps/common/views.py
+++ b/pdc/apps/common/views.py
@@ -9,8 +9,6 @@ from kobo.django.views.generic import ListView
 
 from rest_framework import viewsets, mixins
 
-from contrib.bulk_operations import bulk_operations
-
 from .models import Arch, SigKey, Label
 from . import viewsets as pdc_viewsets
 from .serializers import LabelSerializer, ArchSerializer, SigKeySerializer
@@ -348,54 +346,18 @@ class SigKeyViewSet(pdc_viewsets.StrictQueryParamMixin,
 
         __Method__: `PUT`, `PATCH`
 
-        PATCH: for partial update
+        %(WRITABLE_SERIALIZER)s
+
+        All keys are optional for `PATCH` request, but at least one must be
+        specified.
 
         __URL__: $LINK:sigkey-detail:key_id$
 
-        __Data__:
-
-        %(WRITABLE_SERIALIZER)s
-
         __Response__:
 
         %(SERIALIZER)s
         """
-
-        # NOTE: key_id is a read only field and do not allow to update to
-        # another value, so PATCH is better to take this behavior as the same
-        # as the XMLRPC API.
-        if not kwargs.get('partial', False):
-            return self.http_method_not_allowed(request, *args, **kwargs)
-        else:
-            return super(SigKeyViewSet, self).update(request, *args, **kwargs)
-
-    def bulk_update(self, *args, **kwargs):
-        """
-        ### BULK UPDATE
-
-        Only partial updating is allowed.
-
-        __Method__: PATCH
-
-        The data should include a mapping from `key_id` to a change
-        description. Possible changes are below:
-
-            {"name": "new_name"}
-            or
-            {"description": "new_description"}
-            or
-            {"name": "new_name", "description": "new_description"}
-
-        __URL__: $LINK:sigkey-list$
-
-        __Response__:
-
-        The response will again include a mapping from `key_id` to objects
-        representing the keys. Each key will be shown as follows:
-
-        %(SERIALIZER)s
-        """
-        return bulk_operations.bulk_update_impl(self, *args, **kwargs)
+        return super(SigKeyViewSet, self).update(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         """
@@ -408,7 +370,7 @@ class SigKeyViewSet(pdc_viewsets.StrictQueryParamMixin,
 
         __Data__:
 
-        %(SERIALIZER)s
+        %(WRITABLE_SERIALIZER)s
 
         __Response__:
 


### PR DESCRIPTION
This is consistent with other resources where their string primary
identifier can be changed as well (release_id, product_version_id etc).

This change makes it possible to allow PUT requests to update keys. The
original reason to disable it was because key_id was read-only.

JIRA: PDC-634, PDC-855