### PR TITLE
Make doc of global comp. labels consistent

### DIFF
--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -313,6 +313,11 @@ class GlobalComponentContactRESTTestCase(TestCaseWithChangeSetMixin, APITestCase
         self.assertEqual(response.data['contact']['email'],
                          'person1@test.com')
 
+    def test_list_for_non_int_component_id(self):
+        url = reverse('globalcomponentcontact-list', kwargs={'instance_pk': 'hello'})
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_update_global_component_contact(self):
         url = reverse('globalcomponentcontact-detail', kwargs={'instance_pk': 2,
                                                                'pk': 1})
@@ -487,6 +492,11 @@ class GlobalComponentLabelRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data.get('count'), 1)
         self.assertEqual(response.data.get('results')[0].get('name'), self.args_label1.get('name'))
         self.assertEqual(response.data.get('results')[0].get('description'), self.args_label1.get('description'))
+
+    def test_list_for_non_int_component_id(self):
+        url = reverse('globalcomponentlabel-list', kwargs={'instance_pk': 'hello'})
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_retrieve_specified_global_component_label(self):
         url = reverse('globalcomponentlabel-detail', kwargs={'instance_pk': 1, 'pk': 1})
@@ -821,6 +831,11 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(len(response.data), 5)
         self.assertContains(response, 'release-components', 3)
         self.assertContains(response, 'global-components', 2)
+
+    def test_list_for_non_int_component_id(self):
+        url = reverse('releasecomponentcontact-list', kwargs={'instance_pk': 'hello'})
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_detail_release_component_not_exist(self):
         url = reverse('releasecomponent-detail', kwargs={'pk': 9999})
@@ -1301,6 +1316,11 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('releasecomponentcontact-detail', kwargs={'instance_pk': 1, 'pk': 5})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_single_release_component_contact_with_bad_component_id(self):
+        url = reverse('releasecomponentcontact-detail', kwargs={'instance_pk': 'hello', 'pk': 5})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_assign_label_to_global_component_without_name(self):
         url = reverse('globalcomponentlabel-list', kwargs={'instance_pk': 1})

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -498,34 +498,26 @@ class GlobalComponentLabelViewSet(viewsets.PDCModelViewSet):
 
     def list(self, request, *args, **kwargs):
         """
-        Show the global component labels by pagination, 20 items per page by default, and you can pass some parameters
-        to filter the result.
+        __Method__: `GET`
 
-        __Request__
+        __URL__: $LINK:globalcomponentlabel-list:component_id$
 
-            curl -X GET -H "Content-Type: application/json" $URL:globalcomponentlabel-list:1$
+        __Query params__:
 
-        Or search specified global component's label by label's name.
-
-            curl -G -H "Content-Type: application/json" $URL:globalcomponentlabel-list:1$ -d name=label1
-
-        Now it supports ``name`` to filter the result.
-
-        ``name``: label's name
+        %(FILTERS)s
 
         __Response__: a paged list of following objects
 
         %(SERIALIZER)s
+
         """
         return super(GlobalComponentLabelViewSet, self).list(request, *args, **kwargs)
 
     def retrieve(self, request, *args, **kwargs):
         """
-        Show the specified global component label instance.
+        __Method__: `GET`
 
-        __Request__
-
-            curl -X GET -H "Content-Type: application/json" $URL:globalcomponentlabel-detail:1:1$
+        __URL__: $LINK:globalcomponentlabel-detail:component_id:label_id$
 
         __Response__:
 
@@ -541,19 +533,10 @@ class GlobalComponentLabelViewSet(viewsets.PDCModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         """
-        Delete a label from a specified global component, return an empty response if success.
+        Delete a label from a specified global component, return an empty
+        response if success.
 
-        ####__Request__####
-
-            curl -X DELETE -H "Content-Type: application/json" $URL:globalcomponentlabel-detail:1:1$
-
-        ####__Response__####
-
-            HTTP 204 NO CONTENT
-            Date: Mon, 20 Oct 2014 06:21:21 GMT
-            Content-Length: 0
-            Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-
+        __URL__: $LINK:globalcomponentlabel-detail:component_id:label_id$
         """
         pk = self.kwargs.get('pk')
         label = get_object_or_404(Label, id=pk)
@@ -577,20 +560,19 @@ class GlobalComponentLabelViewSet(viewsets.PDCModelViewSet):
 
         **Note**:  label must exist before being assigned to a global_component.
 
-        ####__Request__####
+        __Method__: `POST`
 
-        ``name``: label's name, **REQUIRED**
+        __URL__: $LINK:globalcomponentlabel-list:component_id$
 
-        ``description``: label's description, **OPTIONAL**
+        __Data__:
 
-            curl -X POST -H "Content-Type: application/json" $URL:globalcomponentlabel-list:1$ -d '{"name": "label1"}'
+            {
+                "name": "string"
+            }
 
-        ####__Response__####
+        __Response__:
 
-            HTTP 201 CREATED
-            Date: Mon, 20 Oct 2014 06:01:04 GMT
-            Content-Type: application/json
-            Allow: GET, POST, HEAD, OPTIONS
+        %(SERIALIZER)s
         """
         extra_keys = set(request.data.keys()) - self.serializer_class().get_allowed_keys()
         StrictSerializerMixin.maybe_raise_error(extra_keys)

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -8,6 +8,7 @@ import types
 
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
+from django.http import Http404
 
 from mptt.exceptions import InvalidMove
 
@@ -338,7 +339,11 @@ class GlobalComponentContactViewSet(HackedComponentContactMixin,
 
     def get_queryset(self):
         gc_id = self.kwargs.get('instance_pk')
-        gc = get_object_or_404(GlobalComponent, id=gc_id)
+        try:
+            gc = get_object_or_404(GlobalComponent, id=gc_id)
+        except ValueError:
+            # Raised when non-numeric instance_pk is given.
+            raise Http404('Global component with id=%s not found' % gc_id)
         return gc.contacts.all()
 
     def list(self, request, *args, **kwargs):
@@ -492,7 +497,11 @@ class GlobalComponentLabelViewSet(viewsets.PDCModelViewSet):
 
     def get_queryset(self):
         gc_id = self.kwargs.get('instance_pk')
-        gc = get_object_or_404(GlobalComponent, id=gc_id)
+        try:
+            gc = get_object_or_404(GlobalComponent, id=gc_id)
+        except ValueError:
+            # Raised when non-numeric instance_pk is given.
+            raise Http404('Global component with id=%s not found' % gc_id)
         labels = gc.labels.all()
         return labels
 
@@ -1078,7 +1087,11 @@ class ReleaseComponentContactViewSet(HackedComponentContactMixin,
 
     def get_queryset(self):
         rc_id = self.kwargs.get("instance_pk", None)
-        release_component = get_object_or_404(ReleaseComponent, pk=rc_id)
+        try:
+            release_component = get_object_or_404(ReleaseComponent, pk=rc_id)
+        except ValueError:
+            # Raised when non-numeric instance_pk is given.
+            raise Http404('Release component with id=%s not found' % rc_id)
         return release_component.contacts.all()
 
     def get_serializer_context(self):
@@ -1128,7 +1141,11 @@ class ReleaseComponentContactViewSet(HackedComponentContactMixin,
         # cannot benefit from DRF built-in features such as pagination.
         rc_id = kwargs.get("instance_pk", None)
         # Release Component object
-        rc = get_object_or_404(ReleaseComponent, pk=rc_id)
+        try:
+            rc = get_object_or_404(ReleaseComponent, pk=rc_id)
+        except ValueError:
+            # Raised when non-numeric instance_pk is given.
+            raise Http404('Release component with id=%s not found' % rc_id)
         gcc_qs = GlobalComponent.objects.get(pk=rc.global_component_id).contacts.all()
         rcc_qs = rc.contacts.all()
         # Contact type based inheritance mechanisms(excerpted from JIRA PDC-184)


### PR DESCRIPTION
The documentation used different format than all other resource.

The create action documentation now does not mention the description
field which is not used anyway. See PDC-611.

The links in documentation lead to page causing internal server error.
While unfortunate, this already happens on global/release component
contacts