### PR TITLE
Separate auto doc test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
     - coverage run --source=contrib,pdc --omit='*tests.py,*/migrations/*,pdc/settings*' manage.py test --settings pdc.settings_test
     - make flake8
+    - make extra_test
 after_success:
     coveralls
 cache:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ cover_test:
 	coverage combine
 	coverage html --rcfile=tox.ini
 
+extra_test:
+	python manage.py test --settings pdc.settings_test tests.check_api_doc
+
 models_svg: export DJANGO_SETTINGS_MODULE=pdc.settings_graph_models
 models_svg:
 	python manage.py graph_models -aE -o docs/source/models_svg/all.svg

--- a/pdc/apps/common/tests.py
+++ b/pdc/apps/common/tests.py
@@ -433,13 +433,3 @@ class FilterDocumentingTestCase(TestCase):
             ' * `key_id` (string)\n'
             ' * `name` (string)'
         )
-
-
-class AutoDocTestCase(APITestCase):
-    def test_no_page_logs_error(self):
-        root = self.client.get(reverse('api-root'))
-        for _, url in root.data.iteritems():
-            with mock.patch('logging.getLogger') as getLogger:
-                self.client.get(url, HTTP_ACCEPT='text/html')
-                self.assertFalse(getLogger.return_value.error.called,
-                                 "%s has bad documentation" % url)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#

--- a/tests/check_api_doc.py
+++ b/tests/check_api_doc.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+"""
+Checks for automatic documentation generators. It verifies no errors are
+logged.
+
+This test should not be part of main test suite as it will run pretty much all
+viewsets without checking anything but the documentation. This makes the code
+coverage go up significantly while there are in fact no tests about those parts
+of code.
+"""
+import mock
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+
+class AutoDocTestCase(APITestCase):
+    def test_no_page_logs_error(self):
+        root = self.client.get(reverse('api-root'))
+        for _, url in root.data.iteritems():
+            with mock.patch('logging.getLogger') as getLogger:
+                self.client.get(url, HTTP_ACCEPT='text/html')
+                err = getLogger.return_value.error
+                self.assertFalse(err.called,
+                                 "%s has bad documentation\nError: %s" % (url, err.call_args))


### PR DESCRIPTION
Move test for auto documentation to a separate module that is not
included in make test. The reason for this is that the test hits most
end-points, but does not check much about them. This is raising the test
coverage significantly which could hide bugs.

The test is still run on Travis-CI and can be run locally via
    $ make extra_test

JIRA: PDC-975