### PR TITLE
Report error when update specifies a read-only key

### DIFF
--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -75,13 +75,7 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('globalcomponent-list')
         data = {'name': 'TestCaseComponent', 'dist_git_path': 'python', 'labels': [{'name': 'label1', 'description': 'abc'}]}
         response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        del response.data['id']
-        del response.data['dist_git_web_url']
-        data.update({'contacts': []})
-        data.update({'labels': []})
-        data.update({'upstream': None})
-        self.assertEqual(response.data, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_global_component_with_upstream(self):
         url = reverse('globalcomponent-list')

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -679,6 +679,7 @@ class OverridesRPMAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_create_correct(self):
         self.override_rpm["rpm_name"] = "bash-debuginfo"
+        del self.override_rpm["id"]
         response = self.client.post(reverse('overridesrpm-list'), self.override_rpm)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(models.OverrideRPM.objects.count(), 2)

--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -234,7 +234,8 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('rpms-detail', args=[3])
         data = {'linked_composes': [u'compose-1']}
         response = self.client.patch(url, data, format='json')
-        self.assertEqual(response.data.get('linked_composes'), [])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
 
     def test_bulk_update_patch(self):
         self.client.patch(reverse('rpms-list'),

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -225,6 +225,12 @@ class ProductUpdateTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(reverse('product-detail', args=['tcudorp']))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_patch_read_only_field(self):
+        response = self.client.patch(reverse('product-detail', args=['product']),
+                                     {'active': True}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
 
 class ProductVersionRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [
@@ -317,6 +323,9 @@ class ProductVersionRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(reverse('productversion-detail', args=['product-1']))
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         response.data['version'] = 2
+        del response.data['product_version_id']
+        del response.data['releases']
+        del response.data['active']
         response = self.client.post(reverse('productversion-list'), response.data)
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(dict(response.data),

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -77,6 +77,7 @@ class RepositorySerializerTestCase(APITestCase):
             self.data[field] = old_val
 
     def test_deserialize_duplicit(self):
+        del self.fixture_data['id']
         serializer = serializers.RepoSerializer(data=self.fixture_data)
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors,
@@ -158,9 +159,11 @@ class RepositoryRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         """The repo has product_id, update tries to change name with product_id unspecified in request."""
         pid = self.existing.pop('product_id')
         self.existing['name'] = 'new_name'
+        id = self.existing.pop('id')
         response = self.client.put(reverse('repo-detail', args=[1]), self.existing, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.existing['product_id'] = pid
+        self.existing['id'] = id
         self.assertDictEqual(dict(response.data), self.existing)
         self.assertNumChanges([1])
 
@@ -326,8 +329,7 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
     ]
 
     def setUp(self):
-        self.repo1 = {"id": 1,
-                      "shadow": False,
+        self.repo1 = {"shadow": False,
                       "release_id": "release-1.1",
                       "variant_uid": "Server",
                       "arch": "x86_64",
@@ -337,8 +339,7 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
                       "content_category": "binary",
                       "name": "test_repo_1",
                       "product_id": 11}
-        self.repo2 = {"id": 2,
-                      "shadow": True,
+        self.repo2 = {"shadow": True,
                       "release_id": "release-1.1",
                       "variant_uid": "Client",
                       "arch": "x86_64",
@@ -382,6 +383,9 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1'}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Drop ids, they are not easily predictable on PostgreSQL
+        for repo in response.data:
+            del repo['id']
         self.assertItemsEqual(response.data, [self.repo1, self.repo2])
         repos = models.Repo.objects.filter(variant_arch__variant__release__release_id='release-1.1')
         self.assertEqual(len(repos), 2)
@@ -394,6 +398,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
                 'include_content_format': ['iso', 'rpm'],
                 'include_content_category': ['debug', 'binary']}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo1, self.repo2])
         repos = models.Repo.objects.filter(variant_arch__variant__release__release_id='release-1.1')
@@ -413,6 +419,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_service': ['pulp']}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])
@@ -421,6 +429,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_repo_family': ['beta']}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])
@@ -429,6 +439,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_content_format': ['iso']}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])
@@ -437,6 +449,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_content_category': ['debug']}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])
@@ -445,6 +459,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_shadow': 'true'}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])
@@ -453,6 +469,8 @@ class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):
         args = {'release_id_from': 'release-1.0', 'release_id_to': 'release-1.1',
                 'include_product_id': 12}
         response = self.client.post(reverse('repoclone-list'), args, format='json')
+        for repo in response.data:
+            del repo['id']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response.data, [self.repo2])
         self.assertNumChanges([1])

--- a/pdc/apps/repository/views.py
+++ b/pdc/apps/repository/views.py
@@ -214,6 +214,8 @@ class RepoCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSet):
         serializer = serializers.RepoSerializer(repos_in_target_release, many=True)
         copy = serializer.data
         for repo in copy:
+            # The serializer will reject read-only fields, so we need to drop the id.
+            del repo['id']
             repo['release_id'] = target_release.release_id
         new_repos = serializers.RepoSerializer(data=copy, many=True)
         if not new_repos.is_valid():
@@ -225,7 +227,7 @@ class RepoCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSet):
             request.changeset.add('Repo', repo_obj.pk,
                                   'null', json.dumps(raw_repo))
 
-        return Response(status=status.HTTP_200_OK, data=copy)
+        return Response(status=status.HTTP_200_OK, data=new_repos.data)
 
 
 class RepoFamilyViewSet(StrictQueryParamMixin,


### PR DESCRIPTION
The fields would otherwise be ignored, which is confusing for the user.
This change required fixing a couple tests. There were tests that
actually checked that the fields are ignored, now they verify that the
request fails.

A bigger change was needed in repository clone view to make sure ids are
not fed into the serializer. This actually fixes an error when
previously the response of repo clone would include old identifiers.

JIRA: PDC-951