### PR TITLE
Enable storing RPM dependencies

### DIFF
--- a/pdc/apps/common/filters.py
+++ b/pdc/apps/common/filters.py
@@ -228,8 +228,11 @@ class CaseInsensitiveBooleanFilter(django_filters.CharFilter):
         if not value:
             return qs
         if value.lower() in self.TRUE_STRINGS:
-            return qs.filter(**{self.name: True})
+            qs = qs.filter(**{self.name: True})
         elif value.lower() in self.FALSE_STRINGS:
-            return qs.filter(**{self.name: False})
+            qs = qs.filter(**{self.name: False})
         else:
-            return qs.none()
+            qs = qs.none()
+        if self.distinct:
+            qs = qs.distinct()
+        return qs

--- a/pdc/apps/common/hacks.py
+++ b/pdc/apps/common/hacks.py
@@ -4,12 +4,15 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+import re
+
 from django.db import connection
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
 from productmd import composeinfo, images, rpms
+from pkg_resources import parse_version
 
 
 def composeinfo_from_str(data):
@@ -113,3 +116,13 @@ def srpm_name_to_component_names(srpm_name):
         return binding_models.ReleaseComponentSRPMNameMapping.get_component_names_by_srpm_name(srpm_name)
     else:
         return [srpm_name]
+
+
+def parse_epoch_version(version):
+    """
+    Wrapper around `pkg_resources.parse_version` that can handle epochs
+    delimited by colon as is customary for RPMs.
+    """
+    if re.match(r'^\d+:', version):
+        version = re.sub(r'^(\d+):', r'\1!', version)
+    return parse_version(version)

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1148,7 +1148,9 @@ class FindComposeMixin(object):
         Output packages with unicode or dict
         """
         packages = [unicode(rpm) for rpm in rpms]
-        return packages if not self.to_dict else [RPMSerializer(rpm).data for rpm in rpms]
+        return (packages
+                if not self.to_dict
+                else [RPMSerializer(rpm, exclude_fields=['dependencies']).data for rpm in rpms])
 
     def _get_query_param_or_false(self, request, query_str):
         value = request.query_params.get(query_str)

--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -3,14 +3,57 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+from functools import partial
+
 from django.conf import settings
 from django.forms import SelectMultiple
+from django.core.exceptions import FieldError
 
 import django_filters
 
-from pdc.apps.common.filters import MultiValueFilter, MultiIntFilter, NullableCharFilter
-from pdc.apps.common.filters import CaseInsensitiveBooleanFilter
+from pdc.apps.common.filters import (MultiValueFilter, MultiIntFilter,
+                                     NullableCharFilter, CaseInsensitiveBooleanFilter)
 from . import models
+
+
+def dependency_filter(type, queryset, value):
+    m = models.Dependency.DEPENDENCY_PARSER.match(value)
+    if not m:
+        raise FieldError('Unrecognized value for filter for {}'.format(type))
+    groups = m.groupdict()
+    queryset = queryset.filter(dependency__name=groups['name'], dependency__type=type).distinct()
+    for dep in models.Dependency.objects.filter(type=type, name=groups['name']):
+
+        is_equal = dep.is_equal(groups['version']) if groups['version'] else False
+        is_lower = dep.is_lower(groups['version']) if groups['version'] else False
+        is_higher = dep.is_higher(groups['version']) if groups['version'] else False
+
+        if groups['op'] == '=' and not dep.is_satisfied_by(groups['version']):
+            queryset = queryset.exclude(pk=dep.rpm_id)
+
+        # User requests everything depending on higher than X
+        elif groups['op'] == '>' and dep.comparison in ('<', '<=', '=') and (is_lower or is_equal):
+            queryset = queryset.exclude(pk=dep.rpm_id)
+
+        # User requests everything depending on lesser than X
+        elif groups['op'] == '<' and dep.comparison in ('>', '>=', '=') and (is_higher or is_equal):
+            queryset = queryset.exclude(pk=dep.rpm_id)
+
+        # User requests everything depending on at least X
+        elif groups['op'] == '>=':
+            if dep.comparison == '<' and (is_lower or is_equal):
+                queryset = queryset.exclude(pk=dep.rpm_id)
+            elif dep.comparison in ('<=', '=') and is_lower:
+                queryset = queryset.exclude(pk=dep.rpm_id)
+
+        # User requests everything depending on at most X
+        elif groups['op'] == '<=':
+            if dep.comparison == '>' and (is_higher or is_equal):
+                queryset = queryset.exclude(pk=dep.rpm_id)
+            elif dep.comparison in ('>=', '=') and is_higher:
+                queryset = queryset.exclude(pk=dep.rpm_id)
+
+    return queryset
 
 
 class RPMFilter(django_filters.FilterSet):
@@ -25,11 +68,26 @@ class RPMFilter(django_filters.FilterSet):
     compose     = MultiValueFilter(name='composerpm__variant_arch__variant__compose__compose_id',
                                    distinct=True)
     linked_release = MultiValueFilter(name='linked_releases__release_id', distinct=True)
+    provides = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                          models.Dependency.PROVIDES))
+    requires = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                          models.Dependency.REQUIRES))
+    obsoletes = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                           models.Dependency.OBSOLETES))
+    conflicts = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                           models.Dependency.CONFLICTS))
+    recommends = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                            models.Dependency.RECOMMENDS))
+    suggests = django_filters.MethodFilter(action=partial(dependency_filter,
+                                                          models.Dependency.SUGGESTS))
+    has_no_deps = CaseInsensitiveBooleanFilter(name='dependency__isnull', distinct=True)
 
     class Meta:
         model = models.RPM
         fields = ('name', 'version', 'epoch', 'release', 'arch', 'srpm_name',
-                  'srpm_nevra', 'compose', 'filename', 'linked_release')
+                  'srpm_nevra', 'compose', 'filename', 'linked_release',
+                  'provides', 'requires', 'obsoletes', 'conflicts', 'recommends', 'suggests',
+                  'has_no_deps')
 
 
 class ImageFilter(django_filters.FilterSet):

--- a/pdc/apps/package/migrations/0005_auto_20150907_0905.py
+++ b/pdc/apps/package/migrations/0005_auto_20150907_0905.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('package', '0004_rpm_linked_releases'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Dependency',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('type', models.PositiveIntegerField(choices=[(1, b'provides'), (2, b'requires'), (3, b'obsoletes'), (4, b'conflicts'), (5, b'recommends'), (6, b'suggests')])),
+                ('name', models.CharField(max_length=200)),
+                ('version', models.CharField(max_length=200, null=True, blank=True)),
+                ('comparison', models.CharField(max_length=50, null=True, blank=True)),
+                ('rpm', models.ForeignKey(to='package.RPM')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='dependency',
+            unique_together=set([('type', 'name', 'version', 'comparison', 'rpm')]),
+        ),
+    ]

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -34,6 +34,26 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
 
         %(FILTERS)s
 
+        If the `has_no_deps` filter is used, the output will only contain RPMs
+        which have some or do not have any dependencies.
+
+        All the dependency filters use the same data format.
+
+        The simpler option is just name of the dependency. In that case it will
+        filter RPMs that depend on that given name.
+
+        The other option is an expression `NAME OP VERSION`. This will filter
+        all RPMs that have a dependency on `NAME` such that adding this
+        constraint will not make the package dependencies inconsistent.
+
+        For example filtering by `python=2.7.0` would include packages with
+        dependency on `python=2.7.0`, `python>=2.6.0`, `python<3.0.0`, but
+        exclude `python=2.6.0`. Filtering by `python<3.0.0` would include
+        packages with `python>2.7.0`, `python=2.6.0`, `python<3.3.0`, but
+        exclude `python>3.1.0` or `python>3.0.0 && python <3.3.0`.
+
+        Only single filter for each dependency type is allowed.
+
         __Response__: a paged list of following objects
 
         %(SERIALIZER)s
@@ -54,6 +74,12 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
         The `srpm_nevra` field should be empty if and only if `arch` is `src`.
         If `filename` is not specified, it will default to a name created from
         *NEVRA*.
+
+        The format of each dependency is either just name of the package that
+        the new RPM depends on, or it can have the format `NAME OP VERSION`,
+        where `OP` can be any comparison operator. Recognized dependency types
+        are *provides*, *requires*, *obsoletes*, *conflicts*, *suggests* and
+        *recommends*
 
         __Response__:
 
@@ -83,6 +109,12 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
         __Data__:
 
         %(WRITABLE_SERIALIZER)s
+
+        If the `dependencies` key is omitted on `PATCH` request, they will not
+        be changed. On `PUT` request, they will be completely removed. When a
+        value is specified, it completely replaces existing dependencies.
+
+        The format of the dependencies themselves is same as for create.
 
         __Response__:
 


### PR DESCRIPTION
Each RPM can have arbitrary number of dependencies of multiple types.
The types are hard-coded, and can not be extended at run-time.

With this patch, it is possible to store and retrieve the dependencies.
There are tests for these parts.

Existing tests have been updated to pass: for RPM tests there are some
minor updates. The compose/package API and its variants are updated not
to include dependencies in their output.

All changes to dependencies are logged in change sets as single update
to the RPM.

The filtering support is not finished yet. So far it is only possible to
get RPMs that depend on a given package with optional equality version
constraint. This is not documented nor covered with unit tests.

JIRA: PDC-955

* [x] Implement filters.
* [x] Check that filters work correctly for all versioning schemes.
* [x] Support versions with epoch.
* [x] Squash migrations before final merge.