### PR TITLE
Move out a single endpoint from "compoese/package"

### DIFF
--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -52,6 +52,7 @@ class ComposeModelTestCase(TestCase):
 
 
 class VersionFinderTestCase(APITestCase):
+    # TODO: This test case could be removed after removing endpoint 'compose/package'
     fixtures = [
         "pdc/apps/common/fixtures/test/sigkey.json",
         "pdc/apps/package/fixtures/test/rpm.json",
@@ -295,6 +296,59 @@ class FindLatestComposeByComposeRPMTestCase(APITestCase):
         url = reverse('findlatestcomposebycr-list', kwargs={'compose_id': 'compose-2', 'rpm_name': 'bash'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class FindCompoeByProductVersionRPMTestCase(APITestCase):
+    fixtures = [
+        "pdc/apps/common/fixtures/test/sigkey.json",
+        "pdc/apps/package/fixtures/test/rpm.json",
+        "pdc/apps/release/fixtures/tests/product.json",
+        "pdc/apps/release/fixtures/tests/product_version.json",
+        "pdc/apps/release/fixtures/tests/release.json",
+        "pdc/apps/compose/fixtures/tests/variant.json",
+        "pdc/apps/compose/fixtures/tests/variant_arch.json",
+        "pdc/apps/compose/fixtures/tests/compose.json",
+        "pdc/apps/compose/fixtures/tests/compose_composerpm.json",
+        "pdc/apps/compose/fixtures/tests/more_composes.json",
+    ]
+
+    def setUp(self):
+        product_version = ProductVersion.objects.get(short='product', version='1')
+        release = Release.objects.get(release_id='release-1.0')
+        release.product_version = product_version
+        release.save()
+        self.url = reverse('findcomposesbypvr-list', kwargs={'rpm_name': 'bash', 'product_version': 'product-1'})
+
+    def test_get_for_product_version(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data,
+                         [{'compose': 'compose-1', 'packages': ['bash-0:1.2.3-4.b1.x86_64.rpm']},
+                          {'compose': 'compose-2', 'packages': ['bash-0:1.2.3-4.b1.x86_64.rpm']},
+                          {'compose': 'compose-3', 'packages': ['bash-0:5.6.7-8.x86_64.rpm']}])
+
+    def test_get_for_product_version_with_latest(self):
+        product_version = ProductVersion.objects.get(short='product', version='1')
+        release = Release.objects.get(release_id='release-1.0')
+        release.product_version = product_version
+        release.save()
+        response = self.client.get(self.url, {'latest': 'True'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data,
+                         [{'compose': 'compose-3', 'packages': ['bash-0:5.6.7-8.x86_64.rpm']}])
+
+    def test_get_for_included_compose_type(self):
+        response = self.client.get(self.url, {'included_compose_type': 'production'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data,
+                         [{'compose': 'compose-1', 'packages': ['bash-0:1.2.3-4.b1.x86_64.rpm']},
+                          {'compose': 'compose-2', 'packages': ['bash-0:1.2.3-4.b1.x86_64.rpm']}])
+
+    def test_get_for_excluded_compose_type(self):
+        response = self.client.get(self.url, {'excluded_compose_type': 'production'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data,
+                         [{'compose': 'compose-3', 'packages': ['bash-0:5.6.7-8.x86_64.rpm']}])
 
 
 class ComposeAPITestCase(TestCaseWithChangeSetMixin, APITestCase):

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1104,11 +1104,22 @@ class FindComposeMixin(object):
             qs = qs.exclude(compose_type__name=self.excluded_compose_type)
         return qs
 
-    def _get_compose_for_release(self):
+    def _get_composes_for_release(self):
         result = []
         composes = Compose.objects.filter(release__release_id=self.release_id)
         composes = self._filter_by_compose_type(composes)
         result = self._get_result(composes, result)
+        return result
+
+    def _get_composes_for_product_version(self):
+        result = []
+        all_composes = []
+        releases = Release.objects.filter(product_version__product_version_id=self.product_version)
+        for release in releases:
+            composes = Compose.objects.filter(release=release)
+            composes = self._filter_by_compose_type(composes)
+            all_composes.extend(composes)
+        result = self._get_result(all_composes, result)
         return result
 
     def _get_result(self, composes, result):
@@ -1220,7 +1231,7 @@ class FindComposeByReleaseRPMViewSet(StrictQueryParamMixin, FindComposeMixin, vi
         self._get_query_param_or_false(request, 'to_dict')
         self.release_id = kwargs.get('release_id')
         self.rpm_name = kwargs.get('rpm_name')
-        return Response(self._get_compose_for_release())
+        return Response(self._get_composes_for_release())
 
 
 class FindLatestComposeByComposeRPMViewSet(StrictQueryParamMixin, FindComposeMixin, viewsets.GenericViewSet):
@@ -1275,6 +1286,61 @@ class FindLatestComposeByComposeRPMViewSet(StrictQueryParamMixin, FindComposeMix
         return Response(self._get_older_compose())
 
 
+class FindComposeByProductVersionRPMViewSet(StrictQueryParamMixin, FindComposeMixin, viewsets.GenericViewSet):
+    """
+    This API endpoint allows finding all composes that contain the package
+    (and include its version) for a given product_version and srpm_name
+    """
+    queryset = ComposeRPM.objects.none()    # Required for permissions
+    extra_query_params = ('included_compose_type', 'excluded_compose_type', 'latest', 'to_dict')
+
+    def list(self, request, **kwargs):
+        """
+        This method allows listing all (compose, package) pairs for a given
+        product_version and RPM name.
+
+        The ordering of composes is performed by the *productmd* library. It
+        first compares compose date, then compose type
+        (`test` < `nightly` < `production`) and lastly respin.
+
+        `latest` is optional parameter. If it is provided, and the value is True, it will
+        return a single pair with the latest compose and its version of the packages.
+
+        `to_dict` is optional parameter, accepted values (True, 'true', 't', 'True', '1'),
+        or (False, 'false', 'f', 'False', '0'). If it is provided, and the value is True,
+        packages' format will be as a dict.
+
+
+        __Method__: GET
+
+        __URL__: $LINK:findcomposesbypvr-list:product_version_id:rpm_name$
+
+        __Query params__:
+
+        %(FILTERS)s
+
+
+        __Response__:
+
+            [
+                {
+                    "compose": string,
+                    "packages": [string]
+                },
+                ...
+            ]
+
+        The list is sorted by compose: oldest first.
+        """
+        self.included_compose_type = request.query_params.get('included_compose_type')
+        self.excluded_compose_type = request.query_params.get('excluded_compose_type')
+        self._get_query_param_or_false(request, 'latest')
+        self._get_query_param_or_false(request, 'to_dict')
+        self.product_version = kwargs.get('product_version')
+        self.rpm_name = kwargs.get('rpm_name')
+        return Response(self._get_composes_for_product_version())
+
+
 class FindComposeWithOlderPackageViewSet(StrictQueryParamMixin, FindComposeMixin,
                                          viewsets.ReadOnlyModelViewSet):
     """
@@ -1295,9 +1361,10 @@ class FindComposeWithOlderPackageViewSet(StrictQueryParamMixin, FindComposeMixin
         with the newest compose older than the given one that has a different
         version of the package.
 
-        Above 2 functions in this endpoint are deprecated. Please use
-        $LINK:findcomposebyrr-list:release_id:rpm_name$ and
-        $LINK:findlatestcomposebycr-list:compose_id:rpm_name$ instead.
+        This endpoint is deprecated. Please use instead:
+        $LINK:findcomposebyrr-list:release_id:rpm_name$,
+        $LINK:findlatestcomposebycr-list:compose_id:rpm_name$,
+        $LINK:findcomposesbypvr-list:product_version:rpm_name$
 
         The ordering of composes is performed by the *productmd* library. It
         first compares compose date, then compose type
@@ -1357,21 +1424,10 @@ class FindComposeWithOlderPackageViewSet(StrictQueryParamMixin, FindComposeMixin
             return Response(status=status.HTTP_400_BAD_REQUEST,
                             data={'detail': 'The rpm_name is required.'})
         if self.release_id:
-            return Response(self._get_compose_for_release())
+            return Response(self._get_composes_for_release())
         if self.compose_id:
             return Response(self._get_older_compose())
         if self.product_version:
-            return Response(self._get_compose_for_product_version())
+            return Response(self._get_composes_for_product_version())
         return Response(status=status.HTTP_400_BAD_REQUEST,
                         data={'detail': 'One of product_version, release or compose argument is required.'})
-
-    def _get_compose_for_product_version(self):
-        result = []
-        all_composes = []
-        releases = Release.objects.filter(product_version__product_version_id=self.product_version)
-        for release in releases:
-            composes = Compose.objects.filter(release=release)
-            composes = self._filter_by_compose_type(composes)
-            all_composes.extend(composes)
-        result = self._get_result(all_composes, result)
-        return result

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -121,6 +121,10 @@ router.register('rpc/find-latest-compose-by-compose-rpm/(?P<compose_id>[^/]+)/(?
                 compose_views.FindLatestComposeByComposeRPMViewSet,
                 base_name='findlatestcomposebycr')
 
+router.register('rpc/find-composes-by-product-version-rpm/(?P<product_version>[^/]+)/(?P<rpm_name>[^/]+)',
+                compose_views.FindComposeByProductVersionRPMViewSet,
+                base_name='findcomposesbypvr')
+
 # register common view sets
 router.register(r'arches', common_views.ArchViewSet)
 router.register(r'sigkeys', common_views.SigKeyViewSet)


### PR DESCRIPTION
Create a new endpoint called
"rpc/find-composes-by-product-version-rpm/{product_version}/{rpm_name}".
The old endpoint "compose/package" has been marked to deperated.
Unit test also added.

JIRA: PDC-944