### PR TITLE
Fixes for default filename

### DIFF
--- a/contrib/bulk_operations/bulk_operations.py
+++ b/contrib/bulk_operations/bulk_operations.py
@@ -31,7 +31,7 @@ def _failure_response(ident, response, data=None):
     Response object that describes the error.
     """
     result = {
-        'invalid_data_id': ident,
+        'id_of_invalid_data': ident,
         'detail': response.data.get('detail', response.data),
     }
     if data:

--- a/contrib/bulk_operations/tests.py
+++ b/contrib/bulk_operations/tests.py
@@ -72,7 +72,7 @@ class BulkOperationTestCase(unittest.TestCase):
         response = wrapped(self.viewset, self.request)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data,
-                         {'invalid_data': 'baz', 'invalid_data_id': 2, 'detail': 'error'})
+                         {'invalid_data': 'baz', 'id_of_invalid_data': 2, 'detail': 'error'})
 
     def test_bulk_destroy(self):
         self.request.data = ['foo', 'bar', 'baz']

--- a/docs/source/bulk_operations.rst
+++ b/docs/source/bulk_operations.rst
@@ -83,15 +83,15 @@ The structure of the response body should (in case of client errors) consist of
 a JSON object with the following structure.::
 
     {
-        "detail":           <string|object>,
-        "invalid_data_id":  <string|int>,
-        "invalid_data":     object
+        "detail":             <string|object>,
+        "id_of_invalid_data": <string|int>,
+        "invalid_data":       object
     }
 
 The ``detail`` key denotes a more precise description of the error. Its value
 is supplied by the single item manipulating function.
 
-The ``invalid_data_id`` describes which part of the request caused the error.
+The ``id_of_invalid_data`` describes which part of the request caused the error.
 For create, it is an integer index from the request array (starting from zero),
 for update or delete it is the identifier.
 

--- a/pdc/apps/contact/tests.py
+++ b/pdc/apps/contact/tests.py
@@ -745,7 +745,7 @@ class PersonBulkRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data,
                          {'detail': {'email': ['This field is required.']},
                           'invalid_data': {'username': 'Alice'},
-                          'invalid_data_id': 0})
+                          'id_of_invalid_data': 0})
         self.assertNumChanges([])
         self.assertEqual(Person.objects.all().count(), 2)
 
@@ -796,7 +796,7 @@ class PersonBulkRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data,
                          {'detail': {'email': ['This field is required.']},
                           'invalid_data': {'username': 'Bob'},
-                          'invalid_data_id': self.mal})
+                          'id_of_invalid_data': self.mal})
         self.assertNumChanges([])
         persons = Person.objects.all()
         self.assertItemsEqual(self.persons, [person.export() for person in persons])
@@ -814,7 +814,7 @@ class PersonBulkRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
                          {'detail': 'Not found.',
                           'invalid_data': {'username': 'Jim',
                                            'email': 'jim@example.com'},
-                          'invalid_data_id': str(self.non_exist_1)})
+                          'id_of_invalid_data': str(self.non_exist_1)})
         self.assertNumChanges([])
         persons = Person.objects.all()
         self.assertItemsEqual(self.persons, [person.export() for person in persons])
@@ -847,7 +847,7 @@ class PersonBulkRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data,
                          {'detail': {'email': ['Enter a valid email address.']},
                           'invalid_data': {'email': 'not-an-email-address'},
-                          'invalid_data_id': self.mal})
+                          'id_of_invalid_data': self.mal})
         self.assertNumChanges([])
         persons = Person.objects.all()
         self.assertItemsEqual(self.persons, [person.export() for person in persons])
@@ -860,7 +860,7 @@ class PersonBulkRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data,
                          {'detail': 'Not found.',
                           'invalid_data': {'email': 'not-an-email-address'},
-                          'invalid_data_id': str(self.non_exist_1)})
+                          'id_of_invalid_data': str(self.non_exist_1)})
         self.assertNumChanges([])
         persons = Person.objects.all()
         self.assertItemsEqual(self.persons, [person.export() for person in persons])

--- a/pdc/apps/package/models.py
+++ b/pdc/apps/package/models.py
@@ -65,10 +65,14 @@ class RPM(models.Model):
 
     @staticmethod
     def default_filename(data):
-        return '%s-%s-%s.%s.rpm' % (data.get('name'),
-                                    data.get('version'),
-                                    data.get('release'),
-                                    data.get('arch'))
+        """
+        Create default file name based on name, version, release and arch. If
+        the data does not contain all these values, None is returned.
+        """
+        try:
+            return '{name}-{version}-{release}.{arch}.rpm'.format(**data)
+        except KeyError:
+            return None
 
     def save(self, *args, **kwargs):
         self.check_srpm_nevra(self.srpm_nevra, self.arch)

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -1623,7 +1623,7 @@ class VariantRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data,
                          {'detail': 'Not found.',
-                          'invalid_data_id': '/release-1.0/Client-UID'})
+                          'id_of_invalid_data': '/release-1.0/Client-UID'})
         self.assertEqual(models.Variant.objects.count(), 2)
         self.assertNumChanges([])
 
@@ -1634,5 +1634,5 @@ class VariantRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data,
                          {'detail': 'Partial update with no changes does not make much sense.',
-                          'invalid_data_id': 'release-1.0/Server-UID'})
+                          'id_of_invalid_data': 'release-1.0/Server-UID'})
         self.assertNumChanges([])

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -581,7 +581,7 @@ class RepoBulkTestCase(TestCaseWithChangeSetMixin, APITestCase):
                                            'content_category': 'binary',
                                            'name': 'repo-1.0-beta-rpms',
                                            'shadow': False},
-                          'invalid_data_id': 1})
+                          'id_of_invalid_data': 1})
         self.assertNumChanges([])
         self.assertEqual(models.Repo.objects.all().count(), 0)
 


### PR DESCRIPTION
There are two mostly unrelated patches in this PR. Both come from the same issue. First patch changes the format of error message of bulk update. The second patch fixes how default RPM filename is generated. See commit message of the second patch for more details.

JIRA: PDC-959