### PR TITLE
Fix RPM epoch filter to not crash on non-numeric values

### DIFF
--- a/pdc/apps/common/renderers.py
+++ b/pdc/apps/common/renderers.py
@@ -176,6 +176,7 @@ FILTER_DEFS = {
     'NullableCharFilter': 'string | null',
     'BooleanFilter': 'bool',
     'ActiveReleasesFilter': 'bool',
+    'MultiIntFilter': 'int',
 }
 LOOKUP_TYPES = {
     'icontains': 'case insensitive, substring match',

--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -8,14 +8,14 @@ from django.forms import SelectMultiple
 
 import django_filters
 
-from pdc.apps.common.filters import MultiValueFilter, NullableCharFilter
+from pdc.apps.common.filters import MultiValueFilter, MultiIntFilter, NullableCharFilter
 from . import models
 
 
 class RPMFilter(django_filters.FilterSet):
     name        = MultiValueFilter()
     version     = MultiValueFilter()
-    epoch       = MultiValueFilter()
+    epoch       = MultiIntFilter()
     release     = MultiValueFilter()
     arch        = MultiValueFilter()
     srpm_name   = MultiValueFilter()

--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -154,6 +154,11 @@ class RPMAPIRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(url + 'wrong_param/', format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_query_with_bad_epoch(self):
+        url = reverse('rpms-list')
+        response = self.client.get(url, {'epoch': 'foo'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_query_with_only_key(self):
         url = reverse('rpms-list')
         response = self.client.get(url + '?name', format='json')


### PR DESCRIPTION
This patch also fixes the documentation to properly show the value
should be an int.

JIRA: PDC-997