### PR TITLE
jira PDC-960, Order resources in client

### DIFF
--- a/pdc_client/bin/pdc_client
+++ b/pdc_client/bin/pdc_client
@@ -182,4 +182,4 @@ if __name__ == "__main__":
         with RequestMethod(client, session, options.resource,
                            options.traceback, options.debug) as request:
             print json.dumps(request.dispatch(options.request, data),
-                             indent=4)
+                             indent=4, sort_keys=True)


### PR DESCRIPTION
Print resources in order when running  'pdc_client -s qa ' shell command.

jira: PDC_960