### PR TITLE
Avoid losing empty list with pdc_client

### DIFF
--- a/pdc_client/bin/pdc_client
+++ b/pdc_client/bin/pdc_client
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     data = load_data(options)
 
     for key, value in data.iteritems():
-        if not value:
+        if options.request == 'GET' and not value:
             # empty string won't be lost
             data[key] = ''
 

--- a/pdc_client/bin/pdc_client
+++ b/pdc_client/bin/pdc_client
@@ -169,6 +169,11 @@ if __name__ == "__main__":
 
     data = load_data(options)
 
+    for key, value in data.iteritems():
+        if not value:
+            # empty string won't be lost
+            data[key] = ''
+
     try:
         client, session = make_client()
     except BeanBagException as e:


### PR DESCRIPTION
With pdc_client, not only for empty list, but empty dictionary,
it will be lost. Convert it to empty string to avoid this case.

Not sure if it is the right fixing.

JIRA: PDC-948