### PR TITLE
Disable paging of repos in release detail

### DIFF
--- a/pdc/apps/release/templates/release_detail.html
+++ b/pdc/apps/release/templates/release_detail.html
@@ -74,7 +74,7 @@
 </table>
 
 <h3 class="sub-header">{% trans 'Repositories' %}</h3>
-<table class="datatable table table-striped table-bordered" data-paging="false">
+<table id="repos" class="table table-striped table-bordered">
  <thead>
   <tr>
     <th class="text-right">#</th>
@@ -108,5 +108,13 @@
 {% endfor %}
  </tbody>
 </table>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    $("#repos").dataTable({
+        "paging": false
+    });
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
The paging on that page is not useful in any way. It was previously
disabled through data attributes, but since test server is using an
outdated version of PatternFly and therefore DataTables, this patch
explicitly disables the paging with JavaScript.

JIRA: PDC-978