### PR TITLE
"not found" enhancement for buld destory overrides with query param.

### DIFF
--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -749,6 +749,10 @@ class OverridesRPMAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(models.OverrideRPM.objects.count(), 0)
         self.assertItemsEqual(response.data, [self.override_rpm])
 
+    def test_clear_with_no_matched_record(self):
+        response = self.client.delete(reverse('overridesrpm-list'), {'release': 'no_such_release'})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_clear_preserve_do_not_delete(self):
         models.OverrideRPM.objects.create(release=self.release, variant="Server", arch="x86_64",
                                           rpm_name="bash-doc", rpm_arch="src", include=True,

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1015,7 +1015,11 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                 return Response(status=status.HTTP_400_BAD_REQUEST,
                                 data=["Allowed keys are release and force (optional, default false)."])
             release_obj = get_object_or_404(Release, release_id=data["release"])
-            return Response(status=status.HTTP_200_OK, data=self._clear(release_obj, data))
+            data = self._clear(release_obj, data)
+            if data:
+                return Response(status=status.HTTP_200_OK, data=data)
+            else:
+                return Response(status=status.HTTP_404_NOT_FOUND, data={'detail': 'Not found.'})
 
         if isinstance(data, list):
             return bulk_operations.bulk_destroy_impl(self, *args, **kwargs)


### PR DESCRIPTION
Return 404 instead of 200 if not found any matched objects.
JIRA: PDC-940