### PR TITLE
Not convert *False* filter.

### DIFF
--- a/pdc_client/bin/pdc_client
+++ b/pdc_client/bin/pdc_client
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     data = load_data(options)
 
     for key, value in data.iteritems():
-        if options.request == 'GET' and not value:
+        if options.request == 'GET' and not value and value is not False:
             # empty string won't be lost
             data[key] = ''
 


### PR DESCRIPTION
Boolean *False* is possible to be a filter of some resource.
Need to exclude it in this hack.