### PR TITLE
Show current tab in URL

### DIFF
--- a/pdc/apps/common/templates/browsable_api/api.html
+++ b/pdc/apps/common/templates/browsable_api/api.html
@@ -65,4 +65,20 @@
 
     </div>
     <!-- END Content -->
+
+    <script type="text/javascript">
+        $(document).ready(function() {
+            if (location.hash !== '') {
+                $('a[href="' + location.hash + '"]').tab('show');
+            }
+            $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+              var hash = '#' + $(e.target).attr('href').substr(1);
+              if (history.pushState) {
+                  history.replaceState(null, '', hash);
+              } else {
+                  location.hash = hash;
+              }
+            });
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
This way it is possible to link to a specific part of the documentation,
not just the list. The whole page is in the history only once, so if
user goes from API root to a resource and clicks all tabs there, a
single click on back button will bring them back to API root.

JIRA: PDC-1011