### PR TITLE
Revisit unique constraint for release component

### DIFF
--- a/pdc/apps/component/migrations/0008_auto_20150914_0925.py
+++ b/pdc/apps/component/migrations/0008_auto_20150914_0925.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('component', '0007_auto_20150821_0834'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='releasecomponent',
+            unique_together=set([('release', 'name')]),
+        ),
+    ]

--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -168,7 +168,7 @@ class ReleaseComponent(models.Model):
 
     class Meta:
         unique_together = [
-            ("release", "global_component", "name"),
+            ("release", "name"),
         ]
 
     def __unicode__(self):

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -862,6 +862,13 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(sorted(response.data), sorted(data))
         self.assertNumChanges([1])
 
+    def test_create_release_component_with_existed_unique_together_fields(self):
+        url = reverse('releasecomponent-list')
+        data = {'release': 'release-1.0', 'name': 'python27'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNumChanges([])
+
     def test_create_release_component_for_non_existing_release(self):
         url = reverse('releasecomponent-list')
         data = {'release': 'hello-1.0',
@@ -1042,7 +1049,7 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('releasecomponent-detail', kwargs={'pk': 1})
         data = {'name': 'MySQL-python'}
         response = self.client.put(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_release_component_only_with_name(self):
         url = reverse('releasecomponent-detail', kwargs={'pk': 1})


### PR DESCRIPTION
Previous release component is uniqued by release, name and global component,
which allows for example to have a release with two release component that
have the same name and different global component.
Change its unique constraint with release and name.

References to release component will be in seperated patch.

JIRA: PDC-1002