### PR TITLE
Find older compose from other releases

### DIFF
--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -297,6 +297,29 @@ class FindOlderComposeByComposeRPMTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_get_compose_from_previous_release(self):
+        r = release_models.Release.objects.create(release_type_id=1, short='release',
+                                                  name='Test Release', version='0.5')
+        for cid in ('compose-1', 'compose-2'):
+            c = models.Compose.objects.get(compose_id=cid)
+            c.release = r
+            c.save()
+        url = reverse('findoldercomposebycr-list', kwargs={'compose_id': 'compose-3', 'rpm_name': 'bash'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('compose'), 'compose-2')
+
+    def test_can_not_get_compose_from_previous_updates_release(self):
+        r = release_models.Release.objects.create(release_type_id=2, short='release',
+                                                  name='Test Release', version='0.5')
+        for cid in ('compose-1', 'compose-2'):
+            c = models.Compose.objects.get(compose_id=cid)
+            c.release = r
+            c.save()
+        url = reverse('findoldercomposebycr-list', kwargs={'compose_id': 'compose-3', 'rpm_name': 'bash'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class FindCompoeByProductVersionRPMTestCase(APITestCase):
     fixtures = [


### PR DESCRIPTION
When requesting an older compose with different version of an RPM, the
composes from previous releases of the same product are explored as
well.

When going back, only GA releases are considered. This way, when
starting from compose for r-1.1-updates or r-1.2, composes from r-1.0
and r-1.1 will be considered, but not from r-1.0-updates.

    r-1.0 --------+- r-1.0-updates -----
                  |
                  \- r-1.1 -----+- r-1.1-updates -----
                                |
                                \- r-1.2 -----

JIRA: PDC-1008