### PR TITLE
Add the missing BuildRequires 'python' for pdc_client.

### DIFF
--- a/pdc_client/pdc-client.spec
+++ b/pdc_client/pdc-client.spec
@@ -10,6 +10,7 @@ License:        MIT
 URL:            https://github.com/release-engineering/product-definition-center
 Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
+BuildRequires:  python
 Requires:       python-requests
 Requires:       python-requests-kerberos
 Requires:       beanbag


### PR DESCRIPTION
Fix JIRA: PDC-1015

NOTE: 'pdc-test' copr repo got updated, after we `tito tag` for pdc-client, this will work for 'pdc' repo as well.