### PR TITLE
Remove rel-eng directory

### DIFF
--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,3 +1,0 @@
-the rel-eng/packages directory contains metadata files
-named after their packages. Each file has the latest tagged
-version and the project's relative directory.

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,5 +1,0 @@
-[buildconfig]
-builder = tito.builder.Builder
-tagger = tito.tagger.VersionTagger
-changelog_do_not_remove_cherrypick = 0
-changelog_format = %s (%ae)


### PR DESCRIPTION
This directory was auto generated and merged when played tito.
Need to be removed.