### PR TITLE
Create new contact API

### DIFF
--- a/pdc/apps/common/renderers.py
+++ b/pdc/apps/common/renderers.py
@@ -144,6 +144,8 @@ class ReadOnlyBrowsableAPIRenderer(BrowsableAPIRenderer):
                 macros['SERIALIZER'] = get_serializer(view, include_read_only=True)
             if '%(WRITABLE_SERIALIZER)s' in docstring:
                 macros['WRITABLE_SERIALIZER'] = get_serializer(view, include_read_only=False)
+            if hasattr(view, 'docstring_macros'):
+                macros.update(view.docstring_macros)
         string = formatting.dedent(docstring)
         formatted = string % macros
         formatted = self.substitute_urls(view, method, formatted)
@@ -288,6 +290,8 @@ def get_field_type(serializer, field_name, field, include_read_only):
         if method:
             docstring = getattr(method, '__doc__')
             return _get_type_from_str(docstring, docstring or 'method')
+    elif not include_read_only and hasattr(field, 'writable_doc_format'):
+        return _get_type_from_str(field.writable_doc_format)
     elif hasattr(field, 'doc_format'):
         return _get_type_from_str(field.doc_format)
     elif isinstance(field, serializers.BaseSerializer):

--- a/pdc/apps/component/filters.py
+++ b/pdc/apps/component/filters.py
@@ -21,7 +21,9 @@ from .models import (GlobalComponent,
 from pdc.apps.contact.models import (Person,
                                      Maillist,
                                      ContactRole,
-                                     RoleContact)
+                                     RoleContact,
+                                     GlobalComponentRoleContact,
+                                     ReleaseComponentRoleContact)
 from pdc.apps.common.filters import (ComposeFilterSet,
                                      value_is_not_empty,
                                      MultiValueFilter,
@@ -298,3 +300,23 @@ class ReleaseComponentRelationshipFilter(ComposeFilterSet):
         model = ReleaseComponentRelationship
         fields = ('type', 'from_component_release', 'from_component_name', 'to_component_release',
                   'to_component_name')
+
+
+class GlobalComponentRoleContactFilter(RoleContactFilter):
+    component_name = MultiValueFilter(name='component__name')
+    role = MultiValueFilter(name='contact_role__name')
+    contact_id = MultiValueFilter(name='contact')
+
+    class Meta:
+        model = GlobalComponentRoleContact
+        fields = ('role', 'email', 'username', 'mail_name', 'component_name', 'contact_id')
+
+
+class ReleaseComponentRoleContactFilter(RoleContactFilter):
+    component_id = MultiValueFilter(name='component__id')
+    role = MultiValueFilter(name='contact_role__name')
+    contact_id = MultiValueFilter(name='contact')
+
+    class Meta:
+        model = ReleaseComponentRoleContact
+        fields = ('role', 'email', 'username', 'mail_name', 'component_id', 'contact_id')

--- a/pdc/apps/component/migrations/0010_migrate_existing_contacts.py
+++ b/pdc/apps/component/migrations/0010_migrate_existing_contacts.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def migrate_rc_contacts(apps, schema_editor):
+    """Migrate contacts stored directly on release components."""
+    RoleContact = apps.get_model('contact', 'RoleContact')
+    ReleaseComponentContact = apps.get_model('contact', 'ReleaseComponentContact')
+    for contact in RoleContact.objects.all():
+        for rc in contact.releasecomponent_set.all():
+            ReleaseComponentContact.objects.create(component=rc,
+                                                   role=contact.contact_role,
+                                                   contact=contact.contact)
+
+def migrate_gc_contacts(apps, schema_editor):
+    """Migrate global components contacts.
+
+    Store directly on global components and add them to release components
+    unless the same type is already provided.
+    """
+    RoleContact = apps.get_model('contact', 'RoleContact')
+    GlobalComponentContact = apps.get_model('contact', 'GlobalComponentContact')
+    ReleaseComponentContact = apps.get_model('contact', 'ReleaseComponentContact')
+    for contact in RoleContact.objects.all():
+        for gc in contact.globalcomponent_set.all():
+            GlobalComponentContact.objects.create(component=gc,
+                                                  role=contact.contact_role,
+                                                  contact=contact.contact)
+            for rc in gc.releasecomponent_set.all():
+                if not ReleaseComponentContact.objects.filter(component=rc,
+                                                              role=contact.contact_role).exists():
+                    ReleaseComponentContact.objects.create(component=rc,
+                                                           role=contact.contact_role,
+                                                           contact=contact.contact)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('component', '0009_releasecomponenttype_has_osbs'),
+        ('contact', '0003_auto_20151001_1309'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_rc_contacts),
+        migrations.RunPython(migrate_gc_contacts),
+    ]

--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -329,17 +329,15 @@ def clone_release_components_and_groups(sender, request, original_release, relea
 
     rc_map = dict()
     for rc in ReleaseComponent.objects.filter(release=original_release):
-        org_rc_pk = rc.pk
-        contacts = rc.contacts.all()
-        rc.pk = None
         if not include_inactive and not rc.active:
             continue
+        org_rc_pk = rc.pk
+        rc.pk = None
         rc.release = release
         if new_dist_git_branch:
             rc.dist_git_branch = new_dist_git_branch
         rc.save()
-        rc.contacts.add(*list(contacts))
-        request.changeset.add("ReleaseComponent", rc.pk, "null", json.dumps(rc.export()))
+        request.changeset.add('releasecomponent', rc.pk, 'null', json.dumps(rc.export()))
         rc_map[org_rc_pk] = rc
 
         releasecomponent_clone.send(sender=rc.__class__,

--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -21,16 +21,6 @@ from pdc.apps.release import signals
 from .signals import releasecomponent_clone
 
 
-__all__ = [
-    'Upstream',
-    'GlobalComponent',
-    'ReleaseComponent',
-    'BugzillaComponent',
-    'ReleaseComponentGroup',
-    'GroupType'
-]
-
-
 def validate_bc_name(name):
     if "/" in name:
         raise ValidationError("Symbol / is not acceptted as part of bugzilla component's name.")

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -13,7 +13,7 @@ from django.utils.text import capfirst
 
 from rest_framework import serializers
 
-from pdc.apps.contact.models import Contact, ContactRole, GlobalComponentRoleContact, ReleaseComponentRoleContact
+from pdc.apps.contact.models import Contact, ContactRole, GlobalComponentContact, ReleaseComponentContact
 from pdc.apps.contact.serializers import RoleContactSerializer, ContactField
 from pdc.apps.common.serializers import DynamicFieldsSerializerMixin, LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.fields import ChoiceSlugField
@@ -430,6 +430,7 @@ class GroupTypeSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 class ReleaseComponentField(serializers.RelatedField):
     """Serializer field for including release component details."""
     doc_format = '{"id": "int", "name": "string", "release": "Release.release_id"}'
+    writable_doc_format = '{"release": "Release.release_id", "name": "string"}'
 
     def to_representation(self, value):
         result = dict()
@@ -540,25 +541,25 @@ class ReleaseComponentRelationshipSerializer(StrictSerializerMixin, serializers.
         fields = ('id', 'type', 'from_component', 'to_component')
 
 
-class GlobalComponentRoleContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
-    component_name = serializers.SlugRelatedField(source='component', slug_field='name', read_only=False,
-                                                  queryset=GlobalComponent.objects.all())
-    role = serializers.SlugRelatedField(source='contact_role', slug_field='name',
-                                        read_only=False, queryset=ContactRole.objects.all())
+class GlobalComponentContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
+    component = serializers.SlugRelatedField(slug_field='name', read_only=False,
+                                             queryset=GlobalComponent.objects.all())
+    role = serializers.SlugRelatedField(slug_field='name', read_only=False,
+                                        queryset=ContactRole.objects.all())
     contact = ContactField()
 
     class Meta:
-        model = GlobalComponentRoleContact
-        fields = ('id', 'component_name', 'role', 'contact')
+        model = GlobalComponentContact
+        fields = ('id', 'component', 'role', 'contact')
 
 
-class ReleaseComponentRoleContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
-    component_id = serializers.SlugRelatedField(source='component', slug_field='id', read_only=False,
-                                                queryset=ReleaseComponent.objects.all())
-    role = serializers.SlugRelatedField(source='contact_role', slug_field='name',
-                                        read_only=False, queryset=ContactRole.objects.all())
+class ReleaseComponentContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
+    component = ReleaseComponentField(read_only=False,
+                                      queryset=ReleaseComponent.objects.all())
+    role = serializers.SlugRelatedField(slug_field='name', read_only=False,
+                                        queryset=ContactRole.objects.all())
     contact = ContactField()
 
     class Meta:
-        model = ReleaseComponentRoleContact
-        fields = ('id', 'component_id', 'role', 'contact')
+        model = ReleaseComponentContact
+        fields = ('id', 'component', 'role', 'contact')

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -13,8 +13,8 @@ from django.utils.text import capfirst
 
 from rest_framework import serializers
 
-from pdc.apps.contact.models import Contact, ContactRole
-from pdc.apps.contact.serializers import RoleContactSerializer
+from pdc.apps.contact.models import Contact, ContactRole, GlobalComponentRoleContact, ReleaseComponentRoleContact
+from pdc.apps.contact.serializers import RoleContactSerializer, ContactField
 from pdc.apps.common.serializers import DynamicFieldsSerializerMixin, LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.fields import ChoiceSlugField
 from pdc.apps.release.models import Release
@@ -549,3 +549,27 @@ class ReleaseComponentRelationshipSerializer(StrictSerializerMixin, serializers.
     class Meta:
         model = ReleaseComponentRelationship
         fields = ('id', 'type', 'from_component', 'to_component')
+
+
+class GlobalComponentRoleContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
+    component_name = serializers.SlugRelatedField(source='component', slug_field='name', read_only=False,
+                                                  queryset=GlobalComponent.objects.all())
+    role = serializers.SlugRelatedField(source='contact_role', slug_field='name',
+                                        read_only=False, queryset=ContactRole.objects.all())
+    contact = ContactField()
+
+    class Meta:
+        model = GlobalComponentRoleContact
+        fields = ('id', 'component_name', 'role', 'contact')
+
+
+class ReleaseComponentRoleContactSerializer(StrictSerializerMixin, serializers.ModelSerializer):
+    component_id = serializers.SlugRelatedField(source='component', slug_field='id', read_only=False,
+                                                queryset=ReleaseComponent.objects.all())
+    role = serializers.SlugRelatedField(source='contact_role', slug_field='name',
+                                        read_only=False, queryset=ContactRole.objects.all())
+    contact = ContactField()
+
+    class Meta:
+        model = ReleaseComponentRoleContact
+        fields = ('id', 'component_id', 'role', 'contact')

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -32,17 +32,6 @@ from .models import (GlobalComponent,
 from . import signals
 
 
-__all__ = (
-    'GlobalComponentSerializer',
-    'ReleaseComponentSerializer',
-    'HackedContactSerializer',
-    'UpstreamSerializer',
-    'BugzillaComponentSerializer',
-    'GroupSerializer',
-    'GroupTypeSerializer'
-)
-
-
 def reverse_url(request, view_name, **kwargs):
     return request.build_absolute_uri(reverse(viewname=view_name,
                                               kwargs=kwargs))

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -19,7 +19,10 @@ from rest_framework.response import Response
 
 from pdc.apps.common import viewsets
 from pdc.apps.common.models import Label
-from pdc.apps.contact.models import RoleContact, ContactRole, GlobalComponentRoleContact, ReleaseComponentRoleContact
+from pdc.apps.contact.models import (RoleContact,
+                                     ContactRole,
+                                     GlobalComponentContact,
+                                     ReleaseComponentContact)
 from pdc.apps.common.serializers import LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.filters import LabelFilter
 from .models import (GlobalComponent,
@@ -39,8 +42,8 @@ from .serializers import (GlobalComponentSerializer,
                           ReleaseComponentRelationshipSerializer,
                           ReleaseComponentTypeSerializer,
                           RCRelationshipTypeSerializer,
-                          GlobalComponentRoleContactSerializer,
-                          ReleaseComponentRoleContactSerializer)
+                          GlobalComponentContactSerializer,
+                          ReleaseComponentContactSerializer)
 from .filters import (ComponentFilter,
                       ReleaseComponentFilter,
                       RoleContactFilter,
@@ -48,8 +51,8 @@ from .filters import (ComponentFilter,
                       GroupFilter,
                       GroupTypeFilter,
                       ReleaseComponentRelationshipFilter,
-                      GlobalComponentRoleContactFilter,
-                      ReleaseComponentRoleContactFilter)
+                      GlobalComponentContactFilter,
+                      ReleaseComponentContactFilter)
 from . import signals
 
 
@@ -103,8 +106,13 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
     serializer_class = GlobalComponentSerializer
     filter_class = ComponentFilter
 
+    # TODO remove deprecation notices from docstrings once 0.2.0 gets out
     def list(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new global
+        component contacts API]($URL:globalcomponentcontacts-list$) instead.
+
         __Method__:
         GET
 
@@ -156,6 +164,10 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new global
+        component contacts API]($URL:globalcomponentcontacts-list$) instead.
+
         __Method__:
         GET
 
@@ -193,6 +205,10 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
 
     def create(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new global
+        component contacts API]($URL:globalcomponentcontacts-list$) instead.
+
         __Method__:
         POST
 
@@ -240,6 +256,10 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
 
     def update(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new global
+        component contacts API]($URL:globalcomponentcontacts-list$) instead.
+
         __Method__:
 
         PUT: for full fields update
@@ -321,19 +341,13 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
         return super(GlobalComponentViewSet, self).destroy(request, *args, **kwargs)
 
 
+# TODO Remove once 0.2.0 gets out
 class GlobalComponentContactViewSet(HackedComponentContactMixin,
                                     viewsets.PDCModelViewSet):
     """
-    ##Overview##
-
-    This page shows the usage of the **Global Component Contact API**, please
-    see the following for more details.
-
-    ##Test tools##
-
-    You can use ``curl`` in terminal, with -X _method_ (GET|POST|PUT|DELETE),
-    -d _data_ (a json string). or GUI plugins for
-    browsers, such as ``RESTClient``, ``RESTConsole``.
+    This API is deprecated and currently provided only for backwards
+    compatibility. Please use [new global component contacts
+    API]($URL:globalcomponentcontacts-list$).
     """
 
     model = GlobalComponent
@@ -671,8 +685,13 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
             qs = qs.filter(release__active=True)
         return qs
 
+    # TODO remove deprecation notices from docstrings once 0.2.0 gets out
     def list(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new release
+        component contacts API]($URL:releasecomponentcontacts-list$) instead.
+
         __Method__:
         GET
 
@@ -730,6 +749,10 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new release
+        component contacts API]($URL:releasecomponentcontacts-list$) instead.
+
         __Method__:
         GET
 
@@ -776,6 +799,10 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
 
     def update(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new release
+        component contacts API]($URL:releasecomponentcontacts-list$) instead.
+
         __Method__:
 
         PUT:
@@ -864,6 +891,10 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
 
     def create(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: the contact field and filters related to it are
+        deprecated and will be remove in next release. Please use [new release
+        component contacts API]($URL:releasecomponentcontacts-list$) instead.
+
         __Method__:
         POST
 
@@ -950,8 +981,13 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         """
         return super(ReleaseComponentViewSet, self).destroy(request, *args, **kwargs)
 
+    # TODO remove this method once 0.2.0 gets out, regular bulk update should be used
     def bulk_update(self, request, *args, **kwargs):
         """
+        **Deprecation notice**: this method is deprecated and will be removed
+        in next release. Please use [new release component contacts
+        API]($URL:releasecomponentcontacts-list$) instead.
+
         __Method__:
         PUT
 
@@ -1050,6 +1086,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         serializer = ReleaseComponentSerializer(instance=qs, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    # TODO enable once 0.2.0 gets out
     def bulk_partial_update(self, request):
         # Without this definition, bulk_operations would pick up PATCH
         # requests, convert them to PUT with kwargs['partial'] = True and an
@@ -1058,19 +1095,13 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
         return self.http_method_not_allowed(request)
 
 
+# TODO Remove once 0.2.0 gets out
 class ReleaseComponentContactViewSet(HackedComponentContactMixin,
                                      viewsets.PDCModelViewSet):
     """
-    ##Overview##
-
-    This page shows the usage of the **Release Component Contact API**, please
-    see the following for more details.
-
-    ##Test tools##
-
-    You can use ``curl`` in terminal, with -X _method_ (GET|POST|PUT|DELETE),
-    -d _data_ (a json string). or GUI plugins for
-    browsers, such as ``RESTClient``, ``RESTConsole``.
+    This API is deprecated and currently provided only for backwards
+    compatibility. Please use [new release component contacts
+    API]($URL:releasecomponentcontacts-list$) instead.
     """
     model = ReleaseComponent
     queryset = ReleaseComponent.objects.all()
@@ -1857,39 +1888,125 @@ class ReleaseComponentRelationshipViewSet(viewsets.PDCModelViewSet):
         return super(ReleaseComponentRelationshipViewSet, self).destroy(request, *args, **kwargs)
 
 
-class GlobalComponentContactInfoViewSet(viewsets.PDCModelViewSet):
+class _BaseContactViewSet(viewsets.PDCModelViewSet):
+    def list(self, *args, **kwargs):
+        """
+        __Method__: `GET`
 
-    queryset = GlobalComponentRoleContact.objects.all()
-    serializer_class = GlobalComponentRoleContactSerializer
-    filter_class = GlobalComponentRoleContactFilter
+        __URL__: $LINK:%(BASENAME)s-list$
 
-    def list(self, request, *args, **kwargs):
-        return super(GlobalComponentContactInfoViewSet, self).list(request, *args, **kwargs)
+        __Query params__:
 
-    def retrieve(self, request, *args, **kwargs):
-        return super(GlobalComponentContactInfoViewSet, self).retrieve(request, *args, **kwargs)
+        %(FILTERS)s
 
-    def destroy(self, request, *args, **kwargs):
-        return super(GlobalComponentContactInfoViewSet, self).destroy(request, *args, **kwargs)
+        The value of `contact` filter should either be a username or mailling
+        list name.
 
-    def update(self, request, *args, **kwargs):
-        return super(GlobalComponentContactInfoViewSet, self).update(request, *args, **kwargs)
+        __Response__: a paged list of following objects
+
+        %(SERIALIZER)s
+        """
+        return super(_BaseContactViewSet, self).list(*args, **kwargs)
+
+    def retrieve(self, *args, **kwargs):
+        """
+        __Method__: `GET`
+
+        __URL__: $LINK:%(BASENAME)s-detail:pk$
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(_BaseContactViewSet, self).retrieve(*args, **kwargs)
+
+    def destroy(self, *args, **kwargs):
+        """Remove association between component and contact.
+
+        __Method__: `GET`
+
+        __URL__: $LINK:%(BASENAME)s-detail:pk$
+
+        __Response__: Nothing on success.
+        """
+        return super(_BaseContactViewSet, self).destroy(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        """Change details about a contact linked to component.
+
+        Please not that if you change the `contact` field here, only the single
+        updated relationship between contact and component will be updated.
+        Specifically, no other component will be affected.
+
+        If you update with new contact details and such contact does not exist
+        yet, it will be automatically created. The specific type will be chosen
+        based on whether `username` or `mail_name` was used.
+
+        __Method__: `PUT`, `PATCH`
+
+        __URL__: $LINK:%(BASENAME)s-detail:pk$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        %(WRITABLE_DATA_COMMENT)s
+
+        View [list of available contact roles]($URL:contactrole-list$).
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(_BaseContactViewSet, self).update(*args, **kwargs)
+
+    def create(self, *args, **kwargs):
+        """Connect contact details with a component.
+
+        If the contact does not exist, it will be created automatically.
+
+        __Method__: `POST`
+
+        __URL__: $LINK:%(BASENAME)s-list$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        %(WRITABLE_DATA_COMMENT)s
+
+        Depending on whether `username` or `mail_name` is used, a person or
+        mailling list will be linked to the component.
+
+        View [list of available contact roles]($URL:contactrole-list$).
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(_BaseContactViewSet, self).create(*args, **kwargs)
 
 
-class ReleaseComponentContactInfoViewSet(viewsets.PDCModelViewSet):
+# TODO Remove Info from name once 0.2.0 gets out
+class GlobalComponentContactInfoViewSet(_BaseContactViewSet):
 
-    queryset = ReleaseComponentRoleContact.objects.all()
-    serializer_class = ReleaseComponentRoleContactSerializer
-    filter_class = ReleaseComponentRoleContactFilter
+    queryset = GlobalComponentContact.objects.all().select_related()
+    serializer_class = GlobalComponentContactSerializer
+    filter_class = GlobalComponentContactFilter
+    docstring_macros = {
+        'BASENAME': 'globalcomponentcontacts',
+        'WRITABLE_DATA_COMMENT': '',
+    }
 
-    def list(self, request, *args, **kwargs):
-        return super(ReleaseComponentContactInfoViewSet, self).list(request, *args, **kwargs)
 
-    def retrieve(self, request, *args, **kwargs):
-        return super(ReleaseComponentContactInfoViewSet, self).retrieve(request, *args, **kwargs)
+# TODO Remove Info from name once 0.2.0 gets out
+class ReleaseComponentContactInfoViewSet(_BaseContactViewSet):
 
-    def destroy(self, request, *args, **kwargs):
-        return super(ReleaseComponentContactInfoViewSet, self).destroy(request, *args, **kwargs)
-
-    def update(self, request, *args, **kwargs):
-        return super(ReleaseComponentContactInfoViewSet, self).update(request, *args, **kwargs)
+    queryset = ReleaseComponentContact.objects.all().select_related()
+    serializer_class = ReleaseComponentContactSerializer
+    filter_class = ReleaseComponentContactFilter
+    docstring_macros = {
+        'BASENAME': 'releasecomponentcontacts',
+        'WRITABLE_DATA_COMMENT': 'The component can be alternatively specified ' +
+                                 'by its id as `{"id": "int"}`.',
+    }

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -19,7 +19,7 @@ from rest_framework.response import Response
 
 from pdc.apps.common import viewsets
 from pdc.apps.common.models import Label
-from pdc.apps.contact.models import RoleContact, ContactRole
+from pdc.apps.contact.models import RoleContact, ContactRole, GlobalComponentRoleContact, ReleaseComponentRoleContact
 from pdc.apps.common.serializers import LabelSerializer, StrictSerializerMixin
 from pdc.apps.common.filters import LabelFilter
 from .models import (GlobalComponent,
@@ -38,14 +38,18 @@ from .serializers import (GlobalComponentSerializer,
                           GroupTypeSerializer,
                           ReleaseComponentRelationshipSerializer,
                           ReleaseComponentTypeSerializer,
-                          RCRelationshipTypeSerializer)
+                          RCRelationshipTypeSerializer,
+                          GlobalComponentRoleContactSerializer,
+                          ReleaseComponentRoleContactSerializer)
 from .filters import (ComponentFilter,
                       ReleaseComponentFilter,
                       RoleContactFilter,
                       BugzillaComponentFilter,
                       GroupFilter,
                       GroupTypeFilter,
-                      ReleaseComponentRelationshipFilter)
+                      ReleaseComponentRelationshipFilter,
+                      GlobalComponentRoleContactFilter,
+                      ReleaseComponentRoleContactFilter)
 from . import signals
 
 
@@ -1851,3 +1855,41 @@ class ReleaseComponentRelationshipViewSet(viewsets.PDCModelViewSet):
         On success, HTTP status code is 204 and the response has no content.
         """
         return super(ReleaseComponentRelationshipViewSet, self).destroy(request, *args, **kwargs)
+
+
+class GlobalComponentContactInfoViewSet(viewsets.PDCModelViewSet):
+
+    queryset = GlobalComponentRoleContact.objects.all()
+    serializer_class = GlobalComponentRoleContactSerializer
+    filter_class = GlobalComponentRoleContactFilter
+
+    def list(self, request, *args, **kwargs):
+        return super(GlobalComponentContactInfoViewSet, self).list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        return super(GlobalComponentContactInfoViewSet, self).retrieve(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        return super(GlobalComponentContactInfoViewSet, self).destroy(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        return super(GlobalComponentContactInfoViewSet, self).update(request, *args, **kwargs)
+
+
+class ReleaseComponentContactInfoViewSet(viewsets.PDCModelViewSet):
+
+    queryset = ReleaseComponentRoleContact.objects.all()
+    serializer_class = ReleaseComponentRoleContactSerializer
+    filter_class = ReleaseComponentRoleContactFilter
+
+    def list(self, request, *args, **kwargs):
+        return super(ReleaseComponentContactInfoViewSet, self).list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        return super(ReleaseComponentContactInfoViewSet, self).retrieve(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        return super(ReleaseComponentContactInfoViewSet, self).destroy(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        return super(ReleaseComponentContactInfoViewSet, self).update(request, *args, **kwargs)

--- a/pdc/apps/contact/apps.py
+++ b/pdc/apps/contact/apps.py
@@ -12,3 +12,4 @@ class ContactConfig(AppConfig):
 
     def ready(self):
         connect_app_models_pre_save_signal(self)
+        from . import signals   # noqa

--- a/pdc/apps/contact/fixtures/tests/contact_role.json
+++ b/pdc/apps/contact/fixtures/tests/contact_role.json
@@ -12,5 +12,12 @@
         "fields": {
             "name": "pm"
         }
+    },
+    {
+        "model": "contact.ContactRole",
+        "pk": 3,
+        "fields": {
+            "name": "cc"
+        }
     }
 ]

--- a/pdc/apps/contact/migrations/0002_auto_20151001_1239.py
+++ b/pdc/apps/contact/migrations/0002_auto_20151001_1239.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('component', '0009_releasecomponenttype_has_osbs'),
+        ('contact', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GlobalComponentRoleContact',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('component', models.ForeignKey(related_name='global_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='component.GlobalComponent')),
+                ('contact', models.ForeignKey(related_name='global_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='contact.Contact')),
+                ('contact_role', models.ForeignKey(related_name='global_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='contact.ContactRole')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ReleaseComponentRoleContact',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('component', models.ForeignKey(related_name='release_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='component.ReleaseComponent')),
+                ('contact', models.ForeignKey(related_name='release_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='contact.Contact')),
+                ('contact_role', models.ForeignKey(related_name='release_component_role_contacts', on_delete=django.db.models.deletion.PROTECT, to='contact.ContactRole')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='releasecomponentrolecontact',
+            unique_together=set([('contact', 'contact_role', 'component')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='globalcomponentrolecontact',
+            unique_together=set([('contact', 'contact_role', 'component')]),
+        ),
+    ]

--- a/pdc/apps/contact/migrations/0003_auto_20151001_1309.py
+++ b/pdc/apps/contact/migrations/0003_auto_20151001_1309.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contact', '0002_auto_20151001_1239'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='globalcomponentrolecontact',
+            name='component',
+            field=models.ForeignKey(to='component.GlobalComponent', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='globalcomponentrolecontact',
+            name='contact',
+            field=models.ForeignKey(to='contact.Contact', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='globalcomponentrolecontact',
+            name='contact_role',
+            field=models.ForeignKey(to='contact.ContactRole', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='releasecomponentrolecontact',
+            name='component',
+            field=models.ForeignKey(to='component.ReleaseComponent', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='releasecomponentrolecontact',
+            name='contact',
+            field=models.ForeignKey(to='contact.Contact', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='releasecomponentrolecontact',
+            name='contact_role',
+            field=models.ForeignKey(to='contact.ContactRole', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterUniqueTogether(
+            name='globalcomponentrolecontact',
+            unique_together=set([('contact_role', 'component')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='releasecomponentrolecontact',
+            unique_together=set([('contact_role', 'component')]),
+        ),
+        migrations.RenameField(
+            model_name='globalcomponentrolecontact',
+            old_name='contact_role',
+            new_name='role',
+        ),
+        migrations.RenameField(
+            model_name='releasecomponentrolecontact',
+            old_name='contact_role',
+            new_name='role',
+        ),
+        migrations.AlterUniqueTogether(
+            name='globalcomponentrolecontact',
+            unique_together=set([('role', 'component')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='releasecomponentrolecontact',
+            unique_together=set([('role', 'component')]),
+        ),
+        migrations.RenameModel(
+            old_name='ReleaseComponentRoleContact',
+            new_name='GlobalComponentContact',
+        ),
+        migrations.RenameModel(
+            old_name='GlobalComponentRoleContact',
+            new_name='ReleaseComponentContact',
+        ),
+        migrations.AlterField(
+            model_name='globalcomponentcontact',
+            name='component',
+            field=models.ForeignKey(to='component.GlobalComponent', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='releasecomponentcontact',
+            name='component',
+            field=models.ForeignKey(to='component.ReleaseComponent', on_delete=django.db.models.deletion.PROTECT),
+        ),
+    ]

--- a/pdc/apps/contact/models.py
+++ b/pdc/apps/contact/models.py
@@ -142,52 +142,46 @@ class RoleContactSpecificManager(models.Manager):
         return self.get_queryset().create(**create_kwargs)
 
 
-class GlobalComponentRoleContact(models.Model):
+class GlobalComponentContact(models.Model):
 
-    contact_role = models.ForeignKey(ContactRole, related_name='global_component_role_contacts',
-                                     on_delete=models.PROTECT)
-    contact      = models.ForeignKey(Contact, related_name='global_component_role_contacts',
-                                     on_delete=models.PROTECT)
-    component = models.ForeignKey('component.GlobalComponent', related_name='global_component_role_contacts',
+    role      = models.ForeignKey(ContactRole, on_delete=models.PROTECT)
+    contact   = models.ForeignKey(Contact, on_delete=models.PROTECT)
+    component = models.ForeignKey('component.GlobalComponent',
                                   on_delete=models.PROTECT)
 
     def __unicode__(self):
-        return u"%s: %s: %s" % (unicode(self.component), self.contact_role, unicode(self.contact))
+        return u'%s: %s: %s' % (unicode(self.component), self.contact_role, unicode(self.contact))
 
     class Meta:
-        unique_together = (
-            ("contact", "contact_role", "component"),
-        )
+        unique_together = (('role', 'component'),)
 
     def export(self, fields=None):
-        result = {'contact': self.contact.export(fields=fields)}
-        result['contact_role'] = self.contact_role.name
-        result['component'] = self.component.name
-        return result
+        return {
+            'contact': self.contact.export(fields=fields),
+            'role': self.role.name,
+            'component': self.component.name,
+        }
 
 
-class ReleaseComponentRoleContact(models.Model):
+class ReleaseComponentContact(models.Model):
 
-    contact_role = models.ForeignKey(ContactRole, related_name='release_component_role_contacts',
-                                     on_delete=models.PROTECT)
-    contact      = models.ForeignKey(Contact, related_name='release_component_role_contacts',
-                                     on_delete=models.PROTECT)
-    component = models.ForeignKey('component.ReleaseComponent', related_name='release_component_role_contacts',
+    role      = models.ForeignKey(ContactRole, on_delete=models.PROTECT)
+    contact   = models.ForeignKey(Contact, on_delete=models.PROTECT)
+    component = models.ForeignKey('component.ReleaseComponent',
                                   on_delete=models.PROTECT)
 
     def __unicode__(self):
-        return u"%s: %s: %s" % (unicode(self.component), self.contact_role, unicode(self.contact))
+        return u'%s: %s: %s' % (unicode(self.component), self.contact_role, unicode(self.contact))
 
     class Meta:
-        unique_together = (
-            ("contact", "contact_role", "component"),
-        )
+        unique_together = (('role', 'component'), )
 
     def export(self, fields=None):
-        result = {'contact': self.contact.export(fields=fields)}
-        result['contact_role'] = self.contact_role.name
-        result['component'] = self.component.name
-        return result
+        return {
+            'contact': self.contact.export(fields=fields),
+            'role': self.role.name,
+            'component': self.component.name,
+        }
 
 
 class RoleContact(models.Model):

--- a/pdc/apps/contact/models.py
+++ b/pdc/apps/contact/models.py
@@ -150,6 +150,54 @@ class RoleContactSpecificManager(models.Manager):
         return self.get_queryset().create(**create_kwargs)
 
 
+class GlobalComponentRoleContact(models.Model):
+
+    contact_role = models.ForeignKey(ContactRole, related_name='global_component_role_contacts',
+                                     on_delete=models.PROTECT)
+    contact      = models.ForeignKey(Contact, related_name='global_component_role_contacts',
+                                     on_delete=models.PROTECT)
+    component = models.ForeignKey('component.GlobalComponent', related_name='global_component_role_contacts',
+                                  on_delete=models.PROTECT)
+
+    def __unicode__(self):
+        return u"%s: %s: %s" % (unicode(self.component), self.contact_role, unicode(self.contact))
+
+    class Meta:
+        unique_together = (
+            ("contact", "contact_role", "component"),
+        )
+
+    def export(self, fields=None):
+        result = {'contact': self.contact.export(fields=fields)}
+        result['contact_role'] = self.contact_role.name
+        result['component'] = self.component.name
+        return result
+
+
+class ReleaseComponentRoleContact(models.Model):
+
+    contact_role = models.ForeignKey(ContactRole, related_name='release_component_role_contacts',
+                                     on_delete=models.PROTECT)
+    contact      = models.ForeignKey(Contact, related_name='release_component_role_contacts',
+                                     on_delete=models.PROTECT)
+    component = models.ForeignKey('component.ReleaseComponent', related_name='release_component_role_contacts',
+                                  on_delete=models.PROTECT)
+
+    def __unicode__(self):
+        return u"%s: %s: %s" % (unicode(self.component), self.contact_role, unicode(self.contact))
+
+    class Meta:
+        unique_together = (
+            ("contact", "contact_role", "component"),
+        )
+
+    def export(self, fields=None):
+        result = {'contact': self.contact.export(fields=fields)}
+        result['contact_role'] = self.contact_role.name
+        result['component'] = self.component.name
+        return result
+
+
 class RoleContact(models.Model):
 
     contact_role = models.ForeignKey(ContactRole, related_name='role_contacts',

--- a/pdc/apps/contact/models.py
+++ b/pdc/apps/contact/models.py
@@ -9,14 +9,6 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
 
-__all__ = [
-    'Person',
-    'Maillist',
-    'ContactRole',
-    'Contact',
-    'RoleContact',
-]
-
 
 class ContactRole(models.Model):
 

--- a/pdc/apps/contact/serializers.py
+++ b/pdc/apps/contact/serializers.py
@@ -42,6 +42,9 @@ class MaillistSerializer(DynamicFieldsSerializerMixin,
 
 
 class ContactField(serializers.DictField):
+    doc_format = '{"id": "int", "email": "email address", "username|mail_name": "string"}'
+    writable_doc_format = '{"email": "email address", "username|mail_name": "string"}'
+
     child = serializers.CharField()
     field_to_class = {
         "username": Person,

--- a/pdc/apps/contact/signals.py
+++ b/pdc/apps/contact/signals.py
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+import json
+
+from django.dispatch import receiver
+
+from . import models
+from pdc.apps.component import signals as component_signals
+
+
+@receiver(component_signals.releasecomponent_clone)
+def clone_osbs_record(sender, request, orig_component_pk, component, **kwargs):
+    for c in models.ReleaseComponentContact.objects.filter(component_id=orig_component_pk):
+        copy = models.ReleaseComponentContact(component=component, contact=c.contact, role=c.role)
+        copy.save()
+        request.changeset.add('releasecomponentcontact', copy.pk, 'null', json.dumps(copy.export()))

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -155,3 +155,10 @@ router.register(r'content-delivery-service', repo_views.ServiceViewSet,
 
 router.register(r'osbs', osbs_views.OSBSViewSet,
                 base_name='osbs')
+
+router.register(r'global-component-contacts',
+                component_views.GlobalComponentContactInfoViewSet,
+                base_name='globalcomponentcontacts')
+router.register(r'release-component-contacts',
+                component_views.ReleaseComponentContactInfoViewSet,
+                base_name='releasecomponentcontacts')


### PR DESCRIPTION
With this API, there is no inheritance between release and global
components. Instead, what would previously be inherited is stored
directly on a release component.

The relationship between a component and a contact is simplified to a
regular Many-to-Many relationship with an intermediate model to point to
role for that contact.

In this patch, new API is added and old tests are adapted to verify it
is correct. There is database schema migration, but the current data is
not migrated.