### PR TITLE
Clone OSBS together with components

### DIFF
--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -18,6 +18,7 @@ from pdc.apps.contact.models import RoleContact
 from pdc.apps.common import hacks
 from pdc.apps.release.models import Release
 from pdc.apps.release import signals
+from .signals import releasecomponent_clone
 
 
 __all__ = [
@@ -350,6 +351,11 @@ def clone_release_components_and_groups(sender, request, original_release, relea
         rc.contacts.add(*list(contacts))
         request.changeset.add("ReleaseComponent", rc.pk, "null", json.dumps(rc.export()))
         rc_map[org_rc_pk] = rc
+
+        releasecomponent_clone.send(sender=rc.__class__,
+                                    request=request,
+                                    orig_component_pk=org_rc_pk,
+                                    component=rc)
 
     for group in ReleaseComponentGroup.objects.filter(release=original_release):
         group_type = group.group_type

--- a/pdc/apps/component/signals.py
+++ b/pdc/apps/component/signals.py
@@ -26,3 +26,11 @@ releasecomponent_serializer_post_create = dispatch.Signal(providing_args=['relea
 
 # This signal is sent after an existing release_component is updated.
 releasecomponent_serializer_post_update = dispatch.Signal(providing_args=['release_component'])
+
+
+# This signal is sent after a release component is cloned. It is a reaction to
+# `pdc.apps.release.signals.release_clone` signal. The handler will get access
+# to request, primary key of the cloned component and the new instance.
+releasecomponent_clone = dispatch.Signal(providing_args=['request',
+                                                         'orig_component_pk',
+                                                         'new_component'])

--- a/pdc/apps/osbs/tests.py
+++ b/pdc/apps/osbs/tests.py
@@ -124,3 +124,13 @@ class OSBSRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertNumChanges([1])
         r = models.OSBSRecord.objects.get(component_id=1)
         self.assertIsNone(r.autorebuild)
+
+    def test_cloning_release_clones_osbs(self):
+        self.client.post(reverse('releaseclone-list'),
+                         {'old_release_id': 'release-1.0', 'version': '1.1'},
+                         format='json')
+        records = models.OSBSRecord.objects.filter(component__release__release_id='release-1.1')
+        self.assertEqual(2, len(records))
+        self.assertTrue(records.get(component__name='python27').autorebuild)
+        self.assertFalse(records.get(component__name='MySQL-python').autorebuild)
+        self.assertNumChanges([6])  # 1 release, 3 components, 2 osbs records


### PR DESCRIPTION
When a new release is cloned from an old one, its components will get
cloned. With this patch, the osbs record is cloned as well, so the list
will not need to be populated again.

JIRA: PDC-958