### PR TITLE
Rename helper function

### DIFF
--- a/pdc/apps/common/hacks.py
+++ b/pdc/apps/common/hacks.py
@@ -15,7 +15,7 @@ from productmd import composeinfo, images, rpms
 from pkg_resources import parse_version
 
 
-def composeinfo_from_str(data):
+def deserialize_composeinfo(data):
     ci = composeinfo.ComposeInfo()
     try:
         ci.deserialize(data)
@@ -32,13 +32,13 @@ def composeinfo_from_str(data):
     return ci
 
 
-def rpms_from_str(data):
+def deserialize_rpms(data):
     rm = rpms.Rpms()
     rm.deserialize(data)
     return rm
 
 
-def images_from_str(data):
+def deserialize_images(data):
     im = images.Images()
     im.deserialize(data)
     return im

--- a/pdc/apps/compose/lib.py
+++ b/pdc/apps/compose/lib.py
@@ -89,8 +89,8 @@ def _add_compose_create_msg(request, compose_obj):
 def compose__import_rpms(request, release_id, composeinfo, rpm_manifest):
     release_obj = release_models.Release.objects.get(release_id=release_id)
 
-    ci = common_hacks.composeinfo_from_str(composeinfo)
-    rm = common_hacks.rpms_from_str(rpm_manifest)
+    ci = common_hacks.deserialize_composeinfo(composeinfo)
+    rm = common_hacks.deserialize_rpms(rpm_manifest)
 
     _maybe_raise_inconsistency_error(ci, rm, 'rpms')
 
@@ -174,8 +174,8 @@ def compose__import_rpms(request, release_id, composeinfo, rpm_manifest):
 def compose__import_images(request, release_id, composeinfo, image_manifest):
     release_obj = release_models.Release.objects.get(release_id=release_id)
 
-    ci = common_hacks.composeinfo_from_str(composeinfo)
-    im = common_hacks.images_from_str(image_manifest)
+    ci = common_hacks.deserialize_composeinfo(composeinfo)
+    im = common_hacks.deserialize_images(image_manifest)
 
     _maybe_raise_inconsistency_error(ci, im, 'images')
 

--- a/pdc/apps/release/lib.py
+++ b/pdc/apps/release/lib.py
@@ -73,7 +73,7 @@ def release__import_from_composeinfo(request, composeinfo_json):
     """
     Import release including variants and architectures from composeinfo json.
     """
-    ci = common_hacks.composeinfo_from_str(composeinfo_json)
+    ci = common_hacks.deserialize_composeinfo(composeinfo_json)
 
     if ci.release.is_layered:
         base_product_obj, _ = _logged_get_or_create(


### PR DESCRIPTION
The common.hacks module defines a couple functions for loading
composeinfo, RPM and image manifests. The methods expect output as a
dict, so they should not be named `_from_str`.