### PR TITLE
Give better error message when importing incorrect composeinfo

### DIFF
--- a/pdc/apps/release/lib.py
+++ b/pdc/apps/release/lib.py
@@ -3,6 +3,7 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+from django.core.exceptions import ValidationError
 from django.db import transaction
 import json
 
@@ -55,16 +56,25 @@ def get_or_create_integrated_release(request, orig_release, release):
         short=release.short.lower(),
         version=release.version.split('.')[0]
     )
-    integrated_release, _ = _logged_get_or_create(
-        request, models.Release,
-        name=release.name,
-        short=release.short.lower(),
-        release_type=orig_release.release_type,
-        version=release.version,
-        base_product=integrated_base_product,
-        integrated_with=orig_release,
-        product_version=integrated_product_version
-    )
+    try:
+        integrated_release, _ = _logged_get_or_create(
+            request, models.Release,
+            name=release.name,
+            short=release.short.lower(),
+            release_type=orig_release.release_type,
+            version=release.version,
+            base_product=integrated_base_product,
+            integrated_with=orig_release,
+            product_version=integrated_product_version
+        )
+    except ValidationError:
+        msg = ('Failed to create release {}-{}-{} for integrated layered product.'
+               + ' A conflicting release already exists.'
+               + ' There is likely a version mismatch between the imported'
+               + ' release and its layered integrated product in the composeinfo.')
+        raise ValidationError(
+            msg.format(release.short.lower(), release.version, integrated_base_product.base_product_id)
+        )
     return integrated_release
 
 

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -1307,6 +1307,22 @@ class ReleaseImportTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.post(reverse('releaseimportcomposeinfo-list'), data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_import_incorrect_layered_product_version_mismatch(self):
+        with open('pdc/apps/release/fixtures/tests/composeinfo.json', 'r') as f:
+            data = json.loads(f.read())
+        # Import version 1.0
+        response = self.client.post(reverse('releaseimportcomposeinfo-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Bump release version and import again. Note that layered product
+        # version remained the same.
+        data['payload']['product']['version'] = '1.1'
+
+        response = self.client.post(reverse('releaseimportcomposeinfo-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('version mismatch', response.content)
+        self.assertIn('sap-1.0-tp-1', response.content)
+
 
 class ReleaseTypeTestCase(TestCaseWithChangeSetMixin, APITestCase):
     def test_list(self):


### PR DESCRIPTION
It can easily happen that the release version is bumped but not its
integrated layered products. The import fails in such case. Now there is
a clear error message explaining what the problem is.

JIRA: PDC-1033