### PR TITLE
Mark required arguments in client create

### DIFF
--- a/pdc_client/plugins/component.py
+++ b/pdc_client/plugins/component.py
@@ -32,12 +32,12 @@ class GlobalComponentPlugin(PDCClientPlugin):
 
         subcmd = self.add_admin_command('global-component-create',
                                         help='create new global component')
-        self.add_global_component_arguments(subcmd)
+        self.add_global_component_arguments(subcmd, required=True)
         subcmd.set_defaults(func=self.global_component_create)
 
-    def add_global_component_arguments(self, parser):
+    def add_global_component_arguments(self, parser, required=False):
         add_parser_arguments(parser, {
-            'name': {},
+            'name': {'required': required},
             'dist_git_path': {}}
         )
         add_parser_arguments(parser, {
@@ -135,21 +135,21 @@ class ReleaseComponentPlugin(PDCClientPlugin):
 
         subcmd = self.add_admin_command('release-component-create',
                                         help='create new release')
-        self.add_release_component_arguments(subcmd)
-        subcmd.add_argument('--release', dest='release')
-        subcmd.add_argument('--global-component', dest='global_component')
+        self.add_release_component_arguments(subcmd, required=True)
+        subcmd.add_argument('--release', dest='release', required=True)
+        subcmd.add_argument('--global-component', dest='global_component', required=True)
         subcmd.set_defaults(func=self.release_component_create)
 
     def add_include_inactive_release_argument(self, parser):
         parser.add_argument('--include-inactive-release', action='store_true',
                             help='show component(s) in both active and inactive releases')
 
-    def add_release_component_arguments(self, parser):
+    def add_release_component_arguments(self, parser, required=False):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--activate', action='store_const', const=True, dest='active')
         group.add_argument('--deactivate', action='store_const', const=False, dest='active')
         add_parser_arguments(parser, {
-            'name': {},
+            'name': {'required': required},
             'dist_git_branch': {},
             'bugzilla_component': {},
             'brew_package': {},

--- a/pdc_client/plugins/release.py
+++ b/pdc_client/plugins/release.py
@@ -31,19 +31,19 @@ class ReleasePlugin(PDCClientPlugin):
 
         subcmd = self.add_admin_command('release-create',
                                         help='create new release')
-        self.add_release_arguments(subcmd)
+        self.add_release_arguments(subcmd, required=True)
         subcmd.set_defaults(func=self.release_create)
 
-    def add_release_arguments(self, parser):
+    def add_release_arguments(self, parser, required=False):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--activate', action='store_const', const=True, dest='active')
         group.add_argument('--deactivate', action='store_const', const=False, dest='active')
         add_parser_arguments(parser, {
-            'version': {},
-            'short': {},
-            'release_type': {},
+            'version': {'required': required},
+            'short': {'required': required},
+            'release_type': {'required': required},
             'product_version': {},
-            'name': {},
+            'name': {'required': required},
             'base_product': {},
             'bugzilla__product': {'arg': 'bugzilla-product'},
             'dist_git__branch': {'arg': 'dist-git-branch'}})

--- a/pdc_client/plugins/rpm.py
+++ b/pdc_client/plugins/rpm.py
@@ -26,7 +26,7 @@ class RPMPlugin(PDCClientPlugin):
 
         subcmd = self.add_admin_command('rpm-create',
                                         help='create new RPM')
-        self.add_rpm_arguments(subcmd)
+        self.add_rpm_arguments(subcmd, required=True)
         subcmd.set_defaults(func=self.rpm_create)
 
         subcmd = self.add_admin_command('rpm-update',
@@ -35,16 +35,16 @@ class RPMPlugin(PDCClientPlugin):
         self.add_rpm_arguments(subcmd)
         subcmd.set_defaults(func=self.rpm_update)
 
-    def add_rpm_arguments(self, parser):
+    def add_rpm_arguments(self, parser, required=False):
         add_parser_arguments(parser, {
-            'arch': {},
-            'epoch': {'type': int},
+            'arch': {'required': required},
+            'epoch': {'type': int, 'required': required},
             'filename': {},
-            'name': {},
-            'release': {},
-            'srpm_name': {},
+            'name': {'required': required},
+            'release': {'required': required},
+            'srpm_name': {'required': required},
             'srpm_nevra': {},
-            'version': {},
+            'version': {'required': required},
             'linked_releases': {'nargs': '*', 'metavar': 'RELEASE_ID'}})
         add_parser_arguments(parser, {
             'dependencies__requires': {'nargs': '*', 'metavar': 'DEPENDENCY', 'arg': 'requires'},

--- a/pdc_client/tests/rpm/tests.py
+++ b/pdc_client/tests/rpm/tests.py
@@ -90,9 +90,10 @@ class RpmTestCase(CLITestCase):
                              '--srpm-name', 'bash',
                              '--epoch', '0',
                              '--version', '4.3.42',
+                             '--arch', 'x86_64',
                              '--release', '1'])
         self.assertEqual(api.calls['rpms'],
-                         [('POST', {'name': 'bash', 'srpm_name': 'bash',
+                         [('POST', {'name': 'bash', 'srpm_name': 'bash', 'arch': 'x86_64',
                                     'epoch': 0, 'version': '4.3.42', 'release': '1'})])
         self.assertEqual(api.calls['rpms/1'],
                          [('GET', {})])


### PR DESCRIPTION
The usage should not wrap required arguments in brackets. The fixed
create commands are for release, rpm, global and release components.

The test for creating RPMs was updated to list all required arguments.

JIRA: PDC-1084, PDC-1079