### PR TITLE
Rename release type field in client output

### DIFF
--- a/pdc_client/plugins/release.py
+++ b/pdc_client/plugins/release.py
@@ -81,7 +81,7 @@ class ReleasePlugin(PDCClientPlugin):
         print fmt.format('Name', release['name'])
         print fmt.format('Short Name', release['short'])
         print fmt.format('Version', release['version'])
-        print fmt.format('Type', release['release_type'])
+        print fmt.format('Release Type', release['release_type'])
         print fmt.format('Product Version', release['product_version'] or '')
         print fmt.format('Base Product', release['base_product'] or '')
         print fmt.format('Activity', 'active' if release['active'] else 'inactive')

--- a/pdc_client/tests/release/data/detail.txt
+++ b/pdc_client/tests/release/data/detail.txt
@@ -2,7 +2,7 @@ Release ID           release-1.0
 Name                 Test Release
 Short Name           release
 Version              1.0
-Type                 ga
+Release Type         ga
 Product Version      release-1
 Base Product         
 Activity             active


### PR DESCRIPTION
All other places refer to the value as "release type". It is better to
keep the work release in the label in the client.

JIRA: PDC-1068