### PR TITLE
Allow empty directories for partners

### DIFF
--- a/pdc/apps/partners/migrations/0002_auto_20151015_1042.py
+++ b/pdc/apps/partners/migrations/0002_auto_20151015_1042.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partners', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='partner',
+            name='ftp_dir',
+            field=models.CharField(max_length=500, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='partner',
+            name='rsync_dir',
+            field=models.CharField(max_length=500, blank=True),
+        ),
+    ]

--- a/pdc/apps/partners/models.py
+++ b/pdc/apps/partners/models.py
@@ -21,8 +21,8 @@ class Partner(models.Model):
     binary = models.BooleanField(default=True)
     source = models.BooleanField(default=True)
     enabled = models.BooleanField(default=True)
-    ftp_dir = models.CharField(max_length=500)
-    rsync_dir = models.CharField(max_length=500)
+    ftp_dir = models.CharField(max_length=500, blank=True)
+    rsync_dir = models.CharField(max_length=500, blank=True)
 
     def __unicode__(self):
         return u'{0.short} ({0.name})'.format(self)


### PR DESCRIPTION
The original issue was not clear on ftp_dir and rsync_dir fields. The
were always required. Turns out the fields should not be. This patch
changes them to accept empty string as possible value.

JIRA: PDC-1048