### PR TITLE
Sort arches in web view

### DIFF
--- a/pdc/apps/common/views.py
+++ b/pdc/apps/common/views.py
@@ -17,7 +17,7 @@ from .filters import LabelFilter, SigKeyFilter
 
 class ArchListView(ListView):
     model = Arch
-    queryset = Arch.objects.all()
+    queryset = Arch.objects.all().order_by('name')
     allow_empty = True
     template_name = "arch_list.html"
     context_object_name = "arch_list"


### PR DESCRIPTION
Up to now, the list was sorted based on the order in which arches were
created. With manually added ones, the order was not correct.

JIRA: PDC-1107