### PR TITLE
Improve help output for create commands

### DIFF
--- a/pdc_client/plugin_helpers.py
+++ b/pdc_client/plugin_helpers.py
@@ -102,6 +102,28 @@ def add_parser_arguments(parser, args, group=None, prefix=DATA_PREFIX):
         parser.add_argument('--' + arg_name, dest=prefix + arg, **kwargs)
 
 
+def add_create_update_args(parser, required_args, optional_args, create=False):
+    """Wrapper around ``add_parser_arguments``.
+
+    If ``create`` is True, one argument group will be created for each of
+    ``required_args`` and ``optional_args``. Each required argument will have
+    the ``required`` parameter set to True automatically.
+
+    If ``create`` is False, only one group of optional arguments will be
+    created containing all the arguments.
+
+    The arguments should be specified the same way as for
+    ``add_parser_arguments``.
+    """
+    if create:
+        for key in required_args:
+            required_args[key]['required'] = True
+        add_parser_arguments(parser, required_args, group='required arguments')
+    else:
+        optional_args.update(required_args)
+    add_parser_arguments(parser, optional_args)
+
+
 def extract_arguments(args, prefix=DATA_PREFIX):
     """Return a dict of arguments created by `add_parser_arguments`.
 

--- a/pdc_client/plugins/component.py
+++ b/pdc_client/plugins/component.py
@@ -8,7 +8,10 @@ import json
 import sys
 
 from pdc_client import get_paged
-from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, extract_arguments
+from pdc_client.plugin_helpers import (PDCClientPlugin,
+                                       add_parser_arguments,
+                                       extract_arguments,
+                                       add_create_update_args)
 
 
 class GlobalComponentPlugin(PDCClientPlugin):
@@ -36,10 +39,10 @@ class GlobalComponentPlugin(PDCClientPlugin):
         subcmd.set_defaults(func=self.global_component_create)
 
     def add_global_component_arguments(self, parser, required=False):
-        add_parser_arguments(parser, {
-            'name': {'required': required},
-            'dist_git_path': {}}
-        )
+        add_create_update_args(parser,
+                               {'name': {}},
+                               {'dist_git_path': {}},
+                               required)
         add_parser_arguments(parser, {
             'upstream__homepage': {'arg': 'homepage'},
             'upstream__scm_type': {'arg': 'scm-type'},
@@ -148,14 +151,14 @@ class ReleaseComponentPlugin(PDCClientPlugin):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--activate', action='store_const', const=True, dest='active')
         group.add_argument('--deactivate', action='store_const', const=False, dest='active')
-        add_parser_arguments(parser, {
-            'name': {'required': required},
-            'dist_git_branch': {},
-            'bugzilla_component': {},
-            'brew_package': {},
-            'type': {},
-            'srpm__name': {'arg': 'srpm-name'}}
-        )
+        add_create_update_args(parser,
+                               {'name': {}},
+                               {'dist_git_branch': {},
+                                'bugzilla_component': {},
+                                'brew_package': {},
+                                'type': {},
+                                'srpm__name': {'arg': 'srpm-name'}},
+                               required)
 
     def list_release_components(self, args):
         filters = extract_arguments(args, prefix='filter_')

--- a/pdc_client/plugins/release.py
+++ b/pdc_client/plugins/release.py
@@ -7,7 +7,9 @@
 import json
 
 from pdc_client import get_paged
-from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, extract_arguments
+from pdc_client.plugin_helpers import (PDCClientPlugin,
+                                       extract_arguments,
+                                       add_create_update_args)
 
 
 class ReleasePlugin(PDCClientPlugin):
@@ -38,15 +40,18 @@ class ReleasePlugin(PDCClientPlugin):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--activate', action='store_const', const=True, dest='active')
         group.add_argument('--deactivate', action='store_const', const=False, dest='active')
-        add_parser_arguments(parser, {
-            'version': {'required': required},
-            'short': {'required': required},
-            'release_type': {'required': required},
+
+        required_args = {
+            'version': {},
+            'short': {},
+            'release_type': {},
+            'name': {}}
+        optional_args = {
             'product_version': {},
-            'name': {'required': required},
             'base_product': {},
             'bugzilla__product': {'arg': 'bugzilla-product'},
-            'dist_git__branch': {'arg': 'dist-git-branch'}})
+            'dist_git__branch': {'arg': 'dist-git-branch'}}
+        add_create_update_args(parser, required_args, optional_args, required)
 
         self.run_hook('release_parser_setup', parser)
 

--- a/pdc_client/plugins/rpm.py
+++ b/pdc_client/plugins/rpm.py
@@ -8,7 +8,10 @@ import sys
 import json
 
 from pdc_client import get_paged
-from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, extract_arguments
+from pdc_client.plugin_helpers import (PDCClientPlugin,
+                                       add_parser_arguments,
+                                       extract_arguments,
+                                       add_create_update_args)
 
 
 class RPMPlugin(PDCClientPlugin):
@@ -36,16 +39,19 @@ class RPMPlugin(PDCClientPlugin):
         subcmd.set_defaults(func=self.rpm_update)
 
     def add_rpm_arguments(self, parser, required=False):
-        add_parser_arguments(parser, {
-            'arch': {'required': required},
-            'epoch': {'type': int, 'required': required},
+        required_args = {
+            'arch': {},
+            'epoch': {'type': int},
+            'name': {},
+            'release': {},
+            'srpm_name': {},
+            'version': {}}
+        optional_args = {
             'filename': {},
-            'name': {'required': required},
-            'release': {'required': required},
-            'srpm_name': {'required': required},
             'srpm_nevra': {},
-            'version': {'required': required},
-            'linked_releases': {'nargs': '*', 'metavar': 'RELEASE_ID'}})
+            'linked_releases': {'nargs': '*', 'metavar': 'RELEASE_ID'}}
+        add_create_update_args(parser, required_args, optional_args, required)
+
         add_parser_arguments(parser, {
             'dependencies__requires': {'nargs': '*', 'metavar': 'DEPENDENCY', 'arg': 'requires'},
             'dependencies__provides': {'nargs': '*', 'metavar': 'DEPENDENCY', 'arg': 'provides'},


### PR DESCRIPTION
Required arguments for create commands are now displayed in a separate
block. For update action, all the arguments end up in one block.

JIRA: PDC-1079