### PR TITLE
Fix wrong method in contact documentation

### DIFF
--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -1932,7 +1932,7 @@ class _BaseContactViewSet(viewsets.PDCModelViewSet):
     def destroy(self, *args, **kwargs):
         """Remove association between component and contact.
 
-        __Method__: `GET`
+        __Method__: `DELETE`
 
         __URL__: $LINK:%(BASENAME)s-detail:pk$
 


### PR DESCRIPTION
Both release component contacts and global component contacts show GET
method for destroying, which is obviously wrong.

JIRA: PDC-1112