### PR TITLE
Return JSON 404 response from Django

### DIFF
--- a/pdc/apps/common/handlers.py
+++ b/pdc/apps/common/handlers.py
@@ -13,6 +13,9 @@ import sys
 import logging
 
 
+NOT_FOUND_JSON_RESPONSE = {'detail': 'Not found'}
+
+
 def exception_handler(exc, context):
     """
     This handler will overwrite rest framework default handler, additionally,
@@ -38,7 +41,7 @@ def exception_handler(exc, context):
             return Response({'detail': msg},
                             status=status.HTTP_400_BAD_REQUEST)
         elif isinstance(exc, exceptions.ObjectDoesNotExist):
-            return Response({'detail': 'Not found'},
+            return Response(NOT_FOUND_JSON_RESPONSE,
                             status=status.HTTP_404_NOT_FOUND)
         elif isinstance(exc, ProtectedError):
             return Response({"detail": "%s %s" % exc.args},

--- a/pdc/apps/common/tests.py
+++ b/pdc/apps/common/tests.py
@@ -4,6 +4,7 @@
 # http://opensource.org/licenses/MIT
 #
 import mock
+import json
 
 from django.test import TestCase
 from django.core.exceptions import ValidationError
@@ -569,3 +570,18 @@ class SerializerDocumentingTestCase(TestCase):
         instance = DummySerializer()
         result = renderers.describe_serializer(instance, True)
         self.assertEqual(result, {'top_level': [{'field': 'string'}]})
+
+
+class JSONResponseFor404(APITestCase):
+    def test_returns_html_without_header(self):
+        response = self.client.get('/foo/bar')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn('<html>', response.content)
+
+    def test_respects_accept_header(self):
+        response = self.client.get('/foo/bar', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        try:
+            json.loads(response.content)
+        except ValueError:
+            self.fail('Response was not JSON')

--- a/pdc/apps/common/views.py
+++ b/pdc/apps/common/views.py
@@ -3,16 +3,21 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+import json
+
 from django.shortcuts import render
+from django.views import defaults
+from django.http import HttpResponse
 
 from kobo.django.views.generic import ListView
 
-from rest_framework import viewsets, mixins
+from rest_framework import viewsets, mixins, status
 
 from .models import Arch, SigKey, Label
 from . import viewsets as pdc_viewsets
 from .serializers import LabelSerializer, ArchSerializer, SigKeySerializer
 from .filters import LabelFilter, SigKeyFilter
+from . import handlers
 
 
 class ArchListView(ListView):
@@ -381,3 +386,11 @@ class SigKeyViewSet(pdc_viewsets.StrictQueryParamMixin,
 
 def home(request):
     return render(request, "home/index.html")
+
+
+def handle404(request):
+    if 'application/json' in request.META.get('HTTP_ACCEPT', ''):
+        return HttpResponse(json.dumps(handlers.NOT_FOUND_JSON_RESPONSE),
+                            status=status.HTTP_404_NOT_FOUND,
+                            content_type='application/json')
+    return defaults.page_not_found(request)

--- a/pdc/urls.py
+++ b/pdc/urls.py
@@ -77,6 +77,8 @@ urlpatterns = [
     url(r'^changes/(?P<id>\d+)/$', ChangesetDetailView.as_view(), name='changeset/detail'),
 ]
 
+handler404 = 'pdc.apps.common.views.handle404'
+
 if settings.DEBUG:
     try:
         import debug_toolbar


### PR DESCRIPTION
When Django generates 404 response, it would always return the rendered
template, which is not nice as the client might be expecting JSON. This
patch adds a check for the Accept HTTP header. If it mentions
application/json MIME type, JSON object is returned instead.

This is automatically picked by pdc_client as it already adds the
header.

JIRA: PDC-1106