### PR TITLE
Improve performance of the web UI

### DIFF
--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -44,7 +44,9 @@ from . import lib
 
 class ComposeListView(SearchView):
     form_class = ComposeSearchForm
-    queryset = Compose.objects.all()
+    queryset = Compose.objects.all() \
+        .select_related('release', 'compose_type') \
+        .prefetch_related('linked_releases')
     allow_empty = True
     template_name = "compose_list.html"
     context_object_name = "compose_list"
@@ -52,7 +54,10 @@ class ComposeListView(SearchView):
 
 
 class ComposeDetailView(DetailView):
-    model = Compose
+    queryset = Compose.objects.select_related('release', 'compose_type') \
+        .prefetch_related('linked_releases', 'variant_set__variantarch_set',
+                          'variant_set__variantarch_set__arch',
+                          'variant_set__variant_type')
     pk_url_kwarg = "id"
     template_name = "compose_detail.html"
 

--- a/pdc/apps/release/templates/product_detail.html
+++ b/pdc/apps/release/templates/product_detail.html
@@ -16,6 +16,6 @@
 </dl>
 
 <h3 class="sub-header">{% trans 'Product Versions' %}</h3>
-{% include "product_version_list_include.html" %}
+{% include "product_version_list_include.html" with product_version_list=product.productversion_set.all %}
 
 {% endblock %}

--- a/pdc/apps/release/templates/product_version_detail.html
+++ b/pdc/apps/release/templates/product_version_detail.html
@@ -20,6 +20,6 @@
 </dl>
 
 <h3 class="sub-header">{% trans 'Releases' %}</h3>
-{% include "release_list_include.html" %}
+{% include "release_list_include.html" with release_list=product_version.release_set.all %}
 
 {% endblock %}

--- a/pdc/apps/release/templates/release_detail.html
+++ b/pdc/apps/release/templates/release_detail.html
@@ -59,9 +59,9 @@
     <td>
         {{ variant.variant_uid }}
         {% if variant.integrated_from %}
-            <span class="pull-right">(integrated from <a href="{% url "release/detail" variant.integrated_from.release.id %}">{{ variant.integrated_from.release.release_id }}</a>)</span>
+            <span class="pull-right">(integrated from <a href="{% url "release/detail" variant.integrated_from.id %}">{{ variant.integrated_from.release_id }}</a>)</span>
         {% elif variant.integrated_to %}
-            <span class="pull-right">(integrated to <a href="{% url "release/detail" variant.integrated_to.release.id %}">{{ variant.integrated_to.release }}</a>)</span>
+            <span class="pull-right">(integrated to <a href="{% url "release/detail" variant.integrated_to.id %}">{{ variant.integrated_to }}</a>)</span>
         {% endif %}
     </td>
     <td>{{ variant.variant_id }}</td>
@@ -89,12 +89,10 @@
   </tr>
  </thead>
  <tbody>
-{% for variant in release.variant_set.all %}
-{% for variantarch in variant.variantarch_set.all %}
-{% for repo in variantarch.repos.all %}
+{% for repo in repos %}
   <tr>
     <td class="text-right">{{ repo.pk }}</td>
-    <td>{{ variant.variant_uid }}.{{ variantarch.arch }}</td>
+    <td>{{ repo.variant_arch.variant.variant_uid }}.{{ repo.variant_arch.arch }}</td>
     <td>{{ repo.service }}</td>
     <td>{{ repo.repo_family }}</td>
     <td>{{ repo.content_format }}</td>
@@ -103,8 +101,6 @@
     <td>{{ repo.name }}</td>
     <td>{{ repo.product_id|default_if_none:"&mdash;" }}</td>
   </tr>
-{% endfor %}
-{% endfor %}
 {% endfor %}
  </tbody>
 </table>

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -435,6 +435,52 @@ class ProductVersionUpdateRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(pv.product.name, 'Test')
 
 
+class ActiveCountTestCase(APITestCase):
+    fixtures = ["pdc/apps/release/fixtures/tests/active-filter.json"]
+
+    def test_active_for_product_version_with_mixed(self):
+        pv = models.ProductVersion.objects.get(pk=3)
+        self.assertTrue(pv.active)
+        self.assertEqual(pv.release_count, 2)
+        self.assertEqual(pv.active_release_count, 1)
+
+    def test_active_for_product_version_with_active_only(self):
+        pv = models.ProductVersion.objects.get(pk=2)
+        self.assertTrue(pv.active)
+        self.assertEqual(pv.release_count, 1)
+        self.assertEqual(pv.active_release_count, 1)
+
+    def test_active_for_product_version_with_inactive_only(self):
+        pv = models.ProductVersion.objects.get(pk=4)
+        self.assertFalse(pv.active)
+        self.assertEqual(pv.release_count, 1)
+        self.assertEqual(pv.active_release_count, 0)
+
+    def test_active_for_product_with_mixed(self):
+        p = models.Product.objects.get(pk=2)
+        self.assertTrue(p.active)
+        self.assertEqual(p.product_version_count, 3)
+        self.assertEqual(p.active_product_version_count, 2)
+        self.assertEqual(p.release_count, 4)
+        self.assertEqual(p.active_release_count, 2)
+
+    def test_active_for_product_with_active_only(self):
+        p = models.Product.objects.get(pk=1)
+        self.assertTrue(p.active)
+        self.assertEqual(p.product_version_count, 1)
+        self.assertEqual(p.active_product_version_count, 1)
+        self.assertEqual(p.release_count, 1)
+        self.assertEqual(p.active_release_count, 1)
+
+    def test_active_for_product_with_inactive_only(self):
+        p = models.Product.objects.get(pk=3)
+        self.assertFalse(p.active)
+        self.assertEqual(p.product_version_count, 1)
+        self.assertEqual(p.active_product_version_count, 0)
+        self.assertEqual(p.release_count, 1)
+        self.assertEqual(p.active_release_count, 0)
+
+
 class ActiveFilterTestCase(APITestCase):
     fixtures = ["pdc/apps/release/fixtures/tests/active-filter.json"]
 
@@ -1309,7 +1355,7 @@ class ReleaseImportTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertItemsEqual(release.trees,
                               ['Client.x86_64', 'Server.x86_64', 'Server.s390x',
                                'Server.ppc64', 'Server-SAP.x86_64'])
-        self.assertEqual(release.variant_set.get(variant_uid='Server-SAP').integrated_from.release.release_id,
+        self.assertEqual(release.variant_set.get(variant_uid='Server-SAP').integrated_from.release_id,
                          'sap-1.0-tp-1')
 
         response = self.client.get(reverse('product-detail', args=['sap']))
@@ -1328,7 +1374,7 @@ class ReleaseImportTestCase(TestCaseWithChangeSetMixin, APITestCase):
                               'active': True, 'release_type': 'ga', 'dist_git': None})
         release = models.Release.objects.get(release_id='sap-1.0-tp-1')
         self.assertItemsEqual(release.trees, ['Server-SAP.x86_64'])
-        self.assertEqual(release.variant_set.get(variant_uid='Server-SAP').integrated_to.release.release_id,
+        self.assertEqual(release.variant_set.get(variant_uid='Server-SAP').integrated_to.release_id,
                          'tp-1.0')
 
     def test_import_via_get(self):

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -20,6 +20,7 @@ from .serializers import (ProductSerializer, ProductVersionSerializer,
                           ReleaseSerializer, BaseProductSerializer,
                           ReleaseTypeSerializer, ReleaseVariantSerializer,
                           VariantTypeSerializer)
+from pdc.apps.repository import models as repo_models
 from pdc.apps.common.viewsets import (ChangeSetModelMixin,
                                       ChangeSetCreateModelMixin,
                                       ChangeSetUpdateModelMixin,
@@ -30,7 +31,7 @@ from . import lib
 
 class ReleaseListView(SearchView):
     form_class = ReleaseSearchForm
-    queryset = models.Release.objects.all()
+    queryset = models.Release.objects.select_related('release_type', 'product_version', 'base_product')
     allow_empty = True
     template_name = "release_list.html"
     context_object_name = "release_list"
@@ -38,9 +39,19 @@ class ReleaseListView(SearchView):
 
 
 class ReleaseDetailView(DetailView):
-    model = models.Release
+    queryset = models.Release.objects.select_related('release_type') \
+        .prefetch_related('variant_set__variant_type',
+                          'variant_set__variantarch_set__arch')
     pk_url_kwarg = "id"
     template_name = "release_detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super(ReleaseDetailView, self).get_context_data(**kwargs)
+        context['repos'] = repo_models.Repo.objects.filter(
+            variant_arch__variant__release=self.object
+        ).select_related('variant_arch', 'variant_arch__arch',
+                         'content_category', 'content_format', 'repo_family', 'service')
+        return context
 
 
 class BaseProductListView(SearchView):
@@ -60,13 +71,15 @@ class BaseProductDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(BaseProductDetailView, self).get_context_data(**kwargs)
-        context["release_list"] = models.Release.objects.filter(base_product=self.get_object().id)
+        context["release_list"] = models.Release.objects.filter(
+            base_product=self.object.id
+        ).select_related('product_version', 'base_product', 'release_type')
         return context
 
 
 class ProductListView(SearchView):
     form_class = ProductSearchForm
-    queryset = models.Product.objects.all()
+    queryset = models.Product.objects.prefetch_related('productversion_set__release_set')
     allow_empty = True
     template_name = "product_list.html"
     context_object_name = "product_list"
@@ -74,15 +87,10 @@ class ProductListView(SearchView):
 
 
 class ProductDetailView(DetailView):
-    model = models.Product
+    queryset = models.Product.objects.prefetch_related('productversion_set__release_set')
     pk_url_kwarg = "id"
     template_name = "product_detail.html"
     context_object_name = "product"
-
-    def get_context_data(self, **kwargs):
-        context = super(ProductDetailView, self).get_context_data(**kwargs)
-        context['product_version_list'] = self.get_object().productversion_set.all()
-        return context
 
 
 class ProductViewSet(ChangeSetCreateModelMixin,
@@ -98,7 +106,7 @@ class ProductViewSet(ChangeSetCreateModelMixin,
     the form of `product_version_id` (both in requests and responses).
     """
 
-    queryset = models.Product.objects.all().prefetch_related('productversion_set')
+    queryset = models.Product.objects.prefetch_related('productversion_set')
     serializer_class = ProductSerializer
     lookup_field = 'short'
     filter_class = filters.ProductFilter
@@ -181,7 +189,7 @@ class ProductVersionViewSet(ChangeSetCreateModelMixin,
     `short` name. Similarly releases are referenced by `release_id`. This
     applies to both requests and responses.
     """
-    queryset = models.ProductVersion.objects.all().select_related('product').prefetch_related('release_set')
+    queryset = models.ProductVersion.objects.select_related('product').prefetch_related('release_set')
     serializer_class = ProductVersionSerializer
     lookup_field = 'product_version_id'
     lookup_value_regex = '[^/]+'
@@ -279,7 +287,7 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
     particular release as well as composes linked to it. It is possible to
     distinguish between these cases by retrieving a detail of the compose.
     """
-    queryset = models.Release.objects.all() \
+    queryset = models.Release.objects \
                      .select_related('product_version', 'release_type', 'base_product') \
                      .prefetch_related('compose_set')
     serializer_class = ReleaseSerializer
@@ -517,7 +525,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
 
 class ProductVersionListView(SearchView):
     form_class = ProductVersionSearchForm
-    queryset = models.ProductVersion.objects.all()
+    queryset = models.ProductVersion.objects.prefetch_related('release_set')
     allow_empty = True
     template_name = "product_version_list.html"
     context_object_name = "product_version_list"
@@ -525,15 +533,10 @@ class ProductVersionListView(SearchView):
 
 
 class ProductVersionDetailView(DetailView):
-    model = models.ProductVersion
+    queryset = models.ProductVersion.objects.prefetch_related('release_set__release_type')
     pk_url_kwarg = "id"
     template_name = "product_version_detail.html"
     context_object_name = "product_version"
-
-    def get_context_data(self, **kwargs):
-        context = super(ProductVersionDetailView, self).get_context_data(**kwargs)
-        context['release_list'] = self.get_object().release_set.all()
-        return context
 
 
 def product_pages(request):


### PR DESCRIPTION
Many of the pages performed lots of database queries. By selecting and
prefetching related data, that number can be brought down significantly.

This patch required rewriting the logic for determining if product or
product version is active. Now it  able to take advantage of the
preloaded data. A test case was added to make sure it works correctly.

JIRA: PDC-1132