### PR TITLE
Role count limit improvements

### DIFF
--- a/pdc/apps/contact/migrations/0005_auto_20151027_0725.py
+++ b/pdc/apps/contact/migrations/0005_auto_20151027_0725.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contact', '0004_auto_20151016_1441'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contactrole',
+            name='count_limit',
+            field=models.PositiveSmallIntegerField(default=1, help_text='Contact count limit of the role for each component.'),
+        ),
+    ]

--- a/pdc/apps/contact/models.py
+++ b/pdc/apps/contact/models.py
@@ -43,7 +43,7 @@ class ContactRole(models.Model):
         return u"%s" % self.name
 
     def export(self, fields=None):
-        _fields = ['name'] if fields is None else fields
+        _fields = ['name', 'count_limit'] if fields is None else fields
         return model_to_dict(self, fields=_fields)
 
 

--- a/pdc/apps/contact/models.py
+++ b/pdc/apps/contact/models.py
@@ -16,8 +16,10 @@ from django.utils.translation import ugettext_lazy as _
 class ContactRole(models.Model):
 
     name = models.CharField(max_length=128, unique=True)
-    count_limit = models.IntegerField(default=1,
-                                      help_text=_('Contact count limit of the role for each component.'))
+    count_limit = models.PositiveSmallIntegerField(
+        default=1,
+        help_text=_('Contact count limit of the role for each component.')
+    )
     UNLIMITED = 0
 
     def _get_max_component_role_count(self, component_model, role):

--- a/pdc/apps/contact/serializers.py
+++ b/pdc/apps/contact/serializers.py
@@ -19,6 +19,7 @@ class LimitField(serializers.IntegerField):
     doc_format = '"{}"|int'.format(UNLIMITED_STR)
 
     def __init__(self, unlimited_value, **kwargs):
+        kwargs['min_value'] = 0
         super(LimitField, self).__init__(**kwargs)
         self.unlimited_value = unlimited_value
 

--- a/pdc/apps/contact/tests.py
+++ b/pdc/apps/contact/tests.py
@@ -111,6 +111,14 @@ class ContactRoleRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
+    def test_update_limit_to_negative(self):
+        response = self.client.patch(reverse('contactrole-detail', args=['allow_3_role']),
+                                     {'count_limit': -1},
+                                     format='json')
+        self.assertIn('greater than or equal to 0',
+                      response.data.get('count_limit')[0])
+        self.assertNumChanges([])
+
 
 class PersonRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = ['pdc/apps/contact/fixtures/tests/person.json', ]

--- a/pdc/apps/contact/tests.py
+++ b/pdc/apps/contact/tests.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from pdc.apps.common.test_utils import TestCaseWithChangeSetMixin
-from .models import RoleContact, Person
+from .models import ContactRole, RoleContact, Person
 
 
 class ContactRoleRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
@@ -93,6 +93,22 @@ class ContactRoleRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("protected", response.content)
+        self.assertNumChanges([])
+
+    def test_update_limit_unlimited(self):
+        response = self.client.patch(reverse('contactrole-detail', args=['allow_3_role']),
+                                     {'count_limit': 'unlimited'},
+                                     format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNumChanges([1])
+        role = ContactRole.objects.get(name='allow_3_role')
+        self.assertEqual(role.count_limit, ContactRole.UNLIMITED)
+
+    def test_update_limit_with_random_string(self):
+        response = self.client.patch(reverse('contactrole-detail', args=['allow_3_role']),
+                                     {'count_limit': 'many'},
+                                     format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
 

--- a/pdc/apps/contact/views.py
+++ b/pdc/apps/contact/views.py
@@ -346,7 +346,7 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
 
             curl -H "Content-Type: application/json"  -X POST -d '{"name": "test"}' $URL:contactrole-list$
             # output
-            {"name": "test"}
+            {"name": "test", "count_limit": 1}
         """
         return super(ContactRoleViewSet, self).create(request, *args, **kwargs)
 
@@ -378,9 +378,11 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
                 "results": [
                     {
                         "name": "qe_leader",
+                        "count_limit": 1
                     },
                     {
                         "name": "qe_group",
+                        "count_limit": 1
                     },
                     ...
                 ]
@@ -397,6 +399,7 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
                 "results": [
                     {
                         "name": "test",
+                        "count_limit": 1
                     }
                 ]
             }
@@ -420,7 +423,7 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
 
             curl -H "Content-Type: application/json" $URL:contactrole-detail:QE_Leader$
             # output
-            {"name": "QE_Leader"}
+            {"name": "QE_Leader", "count_limit": 1}
         """
         return super(ContactRoleViewSet, self).retrieve(request, *args, **kwargs)
 
@@ -446,13 +449,13 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
 
             curl -X PUT -d '{"name": "new_name"}' -H "Content-Type: application/json" $URL:contactrole-detail:QE_Ack$
             # output
-            {"name": "new_name"}
+            {"name": "new_name", "count_limit": 1}
 
         PATCH:
 
-            curl -X PATCH -d '{"name": "new_name"}' -H "Content-Type: application/json" $URL:contactrole-detail:QE_Ack$
+            curl -X PATCH -d '{"count_limit": "unlimited"}' -H "Content-Type: application/json" $URL:contactrole-detail:QE_Ack$
             # output
-            {"name": "new_name"}
+            {"name": "new_name", "count_limit": "unlimited"}
         """
         return super(ContactRoleViewSet, self).update(request, *args, **kwargs)
 


### PR DESCRIPTION
Accept `"unlimited"` as valid input for role count limit and fix the examples.