### PR TITLE
Restructure pdc client command structure 

### DIFF
--- a/pdc_client/plugin_helpers.py
+++ b/pdc_client/plugin_helpers.py
@@ -34,6 +34,8 @@
 
 import logging
 import sys
+import argparse
+
 
 
 DATA_PREFIX = 'data__'
@@ -62,22 +64,28 @@ class PDCClientPlugin(object):
     def register(self):
         raise NotImplementedError('Plugin must implement `register` method.')
 
-    def add_command(self, *args, **kwargs):
-        """Define new subcommand.
+    def set_command(self, *args, **kwargs):
+        """Define new command.
 
         For accepted arguments, see `argparse.ArgumentParser.add_argument`.
         """
-        return self.parser.add_parser(*args, **kwargs)
+        cmd = self.parser.add_parser(*args, **kwargs)
+        # --help-all is used by admin only and hidden in normal `help`.
+        cmd.add_argument('--help-all', action='help', help=argparse.SUPPRESS)
+        self.subparsers = cmd.add_subparsers(metavar='SUB-COMMAND')
 
-    def add_admin_command(self, *args, **kwargs):
-        """Define new admin subcommand.
+    def add_subcommand(self, *args, **kwargs):
+        return self.subparsers.add_parser(*args, **kwargs)
+
+    def add_admin_subcommand(self, *args, **kwargs):
+        """Define new admin sub-command
 
         Help of this subcommand will be hidden for regular --help option, but
         will show when --help-all is used. Otherwise identical to add_command.
         """
         if not self.help_all:
             kwargs.pop('help', None)
-        return self.parser.add_parser(*args, **kwargs)
+        return self.subparsers.add_parser(*args, **kwargs)
 
 
 def add_parser_arguments(parser, args, group=None, prefix=DATA_PREFIX):

--- a/pdc_client/plugins/build_images.py
+++ b/pdc_client/plugins/build_images.py
@@ -13,10 +13,12 @@ from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, ext
 
 class BuildImagePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('build-image-list', help='list all build images')
-        subcmd.add_argument('--show-md5', action='store_true',
+        self.set_command('build-image', help='build images')
+
+        list_parser = self.add_subcommand('list', help='list all build images')
+        list_parser.add_argument('--show-md5', action='store_true',
                             help='whether to display md5 checksums')
-        add_parser_arguments(subcmd, {'component_name': {},
+        add_parser_arguments(list_parser, {'component_name': {},
                                       'rpm_version': {},
                                       'rpm_release': {},
                                       'image_id': {},
@@ -28,12 +30,11 @@ class BuildImagePlugin(PDCClientPlugin):
                                       'archive_md5': {},
                                       'release_id': {}},
                              group='Filtering')
+        list_parser.set_defaults(func=self.list_build_image)
 
-        subcmd.set_defaults(func=self.list_build_image)
-
-        subcmd = self.add_command('build-image-info', help='display details of a build image')
-        subcmd.add_argument('image_id', metavar='IMAGE_ID')
-        subcmd.set_defaults(func=self.build_image_info)
+        info_parser = self.add_subcommand('info', help='display details of a build image')
+        info_parser.add_argument('image_id', metavar='IMAGE_ID')
+        info_parser.set_defaults(func=self.build_image_info)
 
     def _print_build_image_list(self, build_images, with_md5=False):
         fmt = '{image_id}'

--- a/pdc_client/plugins/component.py
+++ b/pdc_client/plugins/component.py
@@ -16,27 +16,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class GlobalComponentPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('global-component-list', help='list all global components')
+        self.set_command('global-component', help='global-component')
+
+        list_parser = self.add_subcommand('list', help='list all global components')
         filters = ('dist_git_path contact_role email label name upstream_homepage upstream_scm_type '
                    'upstream_scm_url'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
-        subcmd.set_defaults(func=self.list_global_components)
+            list_parser.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
+        list_parser.set_defaults(func=self.list_global_components)
 
-        subcmd = self.add_command('global-component-info', help='display details of a global component')
-        subcmd.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
-        subcmd.set_defaults(func=self.global_component_info)
+        info_parser = self.add_subcommand('info', help='display details of a global component')
+        info_parser.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
+        info_parser.set_defaults(func=self.global_component_info)
 
-        subcmd = self.add_admin_command('global-component-update',
-                                        help='update an existing global component')
-        subcmd.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
-        self.add_global_component_arguments(subcmd)
-        subcmd.set_defaults(func=self.global_component_update)
+        update_parser = self.add_subcommand('update', help='update an existing global component')
+        update_parser.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
+        self.add_global_component_arguments(update_parser)
+        update_parser.set_defaults(func=self.global_component_update)
 
-        subcmd = self.add_admin_command('global-component-create',
-                                        help='create new global component')
-        self.add_global_component_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.global_component_create)
+        create_parser = self.add_subcommand('create', help='create new global component')
+        self.add_global_component_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.global_component_create)
 
     def add_global_component_arguments(self, parser, required=False):
         add_create_update_args(parser,
@@ -117,31 +117,31 @@ class GlobalComponentPlugin(PDCClientPlugin):
 
 class ReleaseComponentPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('release-component-list', help='list all release components')
-        self.add_include_inactive_release_argument(subcmd)
+        self.set_command('release-component', help='release component')
+
+        list_parser = self.add_subcommand('list', help='list all release components')
+        self.add_include_inactive_release_argument(list_parser)
         filters = ('active brew_package bugzilla_component contact_role email global_component name release srpm_name '
                    'type'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
-        subcmd.set_defaults(func=self.list_release_components)
+            list_parser.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
+        list_parser.set_defaults(func=self.list_release_components)
 
-        subcmd = self.add_command('release-component-info', help='display details of a release component')
-        self.add_include_inactive_release_argument(subcmd)
-        subcmd.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
-        subcmd.set_defaults(func=self.release_component_info)
+        info_parser = self.add_subcommand('info', help='display details of a release component')
+        self.add_include_inactive_release_argument(info_parser)
+        info_parser.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
+        info_parser.set_defaults(func=self.release_component_info)
 
-        subcmd = self.add_admin_command('release-component-update',
-                                        help='update an existing release component')
-        subcmd.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
-        self.add_release_component_arguments(subcmd)
-        subcmd.set_defaults(func=self.release_component_update)
+        update_parser = self.add_subcommand('update', help='update an existing release component')
+        update_parser.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
+        self.add_release_component_arguments(update_parser)
+        update_parser.set_defaults(func=self.release_component_update)
 
-        subcmd = self.add_admin_command('release-component-create',
-                                        help='create new release')
-        self.add_release_component_arguments(subcmd, required=True)
-        subcmd.add_argument('--release', dest='release', required=True)
-        subcmd.add_argument('--global-component', dest='global_component', required=True)
-        subcmd.set_defaults(func=self.release_component_create)
+        create_parser = self.add_subcommand('create', help='create new release component')
+        self.add_release_component_arguments(create_parser, required=True)
+        create_parser.add_argument('--release', dest='release', required=True)
+        create_parser.add_argument('--global-component', dest='global_component', required=True)
+        create_parser.set_defaults(func=self.release_component_create)
 
     def add_include_inactive_release_argument(self, parser):
         parser.add_argument('--include-inactive-release', action='store_true',

--- a/pdc_client/plugins/compose.py
+++ b/pdc_client/plugins/compose.py
@@ -12,23 +12,25 @@ from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, ext
 
 class ComposePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('compose-list', help='list all composes')
-        subcmd.add_argument('--deleted', action='store_true',
+        self.set_command('compose', help='compose')
+
+        list_parser = self.add_subcommand('list', help='list all composes')
+        list_parser.add_argument('--deleted', action='store_true',
                             help='show deleted composes')
-        subcmd.set_defaults(func=self.list_composes)
+        list_parser.set_defaults(func=self.list_composes)
 
-        subcmd = self.add_command('compose-info', help='display details of a compose')
-        subcmd.add_argument('compose_id', metavar='COMPOSE_ID')
-        subcmd.set_defaults(func=self.compose_info)
+        info_parser = self.add_subcommand('info', help='display details of a compose')
+        info_parser.add_argument('compose_id', metavar='COMPOSE_ID')
+        info_parser.set_defaults(func=self.compose_info)
 
-        subcmd = self.add_admin_command('compose-update',
+        update_parser = self.add_admin_subcommand('update',
                                         help='partial update an existing compose.',
                                         description='only some compose fields can be modified by this call.\
-                                                    these are acceptance_testing, linked_releases and rtt_tested_architectures.')
-        subcmd.add_argument('compose_id', metavar='COMPOSE_ID')
-        self.add_compose_arguments(subcmd)
-        subcmd.set_defaults(func=self.compose_update)
-        self.compose_update = subcmd
+                                            these are acceptance_testing, linked_releases and rtt_tested_architectures.')
+        update_parser.add_argument('compose_id', metavar='COMPOSE_ID')
+        self.add_compose_arguments(update_parser)
+        update_parser.set_defaults(func=self.compose_update)
+        self.compose_update = update_parser
 
     def add_compose_arguments(self, parser):
         add_parser_arguments(parser, {

--- a/pdc_client/plugins/image.py
+++ b/pdc_client/plugins/image.py
@@ -31,10 +31,12 @@ def size_format(num):
 
 class ImagePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('image-list', help='list all images')
-        subcmd.add_argument('--show-sha256', action='store_true',
+        self.set_command('image', help='image')
+
+        list_parser = self.add_subcommand('list', help='list all images')
+        list_parser.add_argument('--show-sha256', action='store_true',
                             help='whether to display SHA256 checksums along with the file names')
-        add_parser_arguments(subcmd, {'arch': {},
+        add_parser_arguments(list_parser, {'arch': {},
                                       'compose': {},
                                       'file_name': {},
                                       'image_format': {},
@@ -45,13 +47,12 @@ class ImagePlugin(PDCClientPlugin):
                                       'sha256': {},
                                       'volume_id': {}},
                              group='Filtering')
-        subcmd.set_defaults(func=self.image_list)
+        list_parser.set_defaults(func=self.image_list)
 
-        subcmd = self.add_command('image-info', help='display details of an image',
-                                  description=info_desc)
-        subcmd.add_argument('filename', metavar='FILENAME')
-        subcmd.add_argument('--sha256', nargs='?')
-        subcmd.set_defaults(func=self.image_info)
+        info_parser = self.add_subcommand('info', help='display details of an image', description=info_desc)
+        info_parser.add_argument('filename', metavar='FILENAME')
+        info_parser.add_argument('--sha256', nargs='?')
+        info_parser.set_defaults(func=self.image_info)
 
     def _print_image_list(self, images, with_sha=False):
         fmt = '{file_name}'

--- a/pdc_client/plugins/permission.py
+++ b/pdc_client/plugins/permission.py
@@ -11,8 +11,10 @@ from pdc_client.plugin_helpers import PDCClientPlugin
 
 class PermissionPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('list-my-permissions', help='list my permissions')
-        subcmd.set_defaults(func=self.permission_list)
+        self.set_command('permission', help='permission')
+
+        list_parser = self.add_subcommand('list', help='list my permissions')
+        list_parser.set_defaults(func=self.permission_list)
 
     def permission_list(self, args):
         permissions = self.__get_permissions(self.client.auth['current-user'])

--- a/pdc_client/plugins/release.py
+++ b/pdc_client/plugins/release.py
@@ -14,27 +14,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class ReleasePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('release-list', help='list all releases')
-        subcmd.add_argument('--inactive', action='store_true',
+        self.set_command('release', help='release')
+
+        list_parser = self.add_subcommand('list', help='list all releases')
+        list_parser.add_argument('--inactive', action='store_true',
                             help='show only inactive releases')
-        subcmd.add_argument('--all', action='store_true',
+        list_parser.add_argument('--all', action='store_true',
                             help='show both active and inactive releases')
-        subcmd.set_defaults(func=self.list_releases)
+        list_parser.set_defaults(func=self.list_releases)
 
-        subcmd = self.add_command('release-info', help='display details of a release')
-        subcmd.add_argument('release_id', metavar='RELEASE_ID')
-        subcmd.set_defaults(func=self.release_info)
+        info_parser = self.add_subcommand('info', help='display details of a release')
+        info_parser.add_argument('release_id', metavar='RELEASE_ID')
+        info_parser.set_defaults(func=self.release_info)
 
-        subcmd = self.add_admin_command('release-update',
-                                        help='update an existing release')
-        subcmd.add_argument('release_id', metavar='RELEASE_ID')
-        self.add_release_arguments(subcmd)
-        subcmd.set_defaults(func=self.release_update)
+        update_parser = self.add_admin_subcommand('update', help='update an existing release')
+        update_parser.add_argument('release_id', metavar='RELEASE_ID')
+        self.add_release_arguments(update_parser)
+        update_parser.set_defaults(func=self.release_update)
 
-        subcmd = self.add_admin_command('release-create',
-                                        help='create new release')
-        self.add_release_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.release_create)
+        create_parser = self.add_admin_subcommand('create', help='create new release')
+        self.add_release_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.release_create)
 
     def add_release_arguments(self, parser, required=False):
         group = parser.add_mutually_exclusive_group()

--- a/pdc_client/plugins/rpm.py
+++ b/pdc_client/plugins/rpm.py
@@ -16,27 +16,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class RPMPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('rpm-list', help='list all rpms')
+        self.set_command('rpm', help='rpm')
+
+        list_parser = self.add_subcommand('list', help='list all rpms')
         filters = ('name version release arch compose conflicts obsoletes provides '
                    'suggests recommends requires'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg, dest='filter_' + arg)
-        subcmd.set_defaults(func=self.rpm_list)
+            list_parser.add_argument('--' + arg, dest='filter_' + arg)
+        list_parser.set_defaults(func=self.rpm_list)
 
-        subcmd = self.add_command('rpm-info', help='display details of an RPM')
-        subcmd.add_argument('rpmid', metavar='ID')
-        subcmd.set_defaults(func=self.rpm_info)
+        info_parser = self.add_subcommand('info', help='display details of an RPM')
+        info_parser.add_argument('rpmid', metavar='ID')
+        info_parser.set_defaults(func=self.rpm_info)
 
-        subcmd = self.add_admin_command('rpm-create',
-                                        help='create new RPM')
-        self.add_rpm_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.rpm_create)
+        create_parser = self.add_admin_subcommand('create', help='create new RPM')
+        self.add_rpm_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.rpm_create)
 
-        subcmd = self.add_admin_command('rpm-update',
-                                        help='update existing RPM')
-        subcmd.add_argument('rpmid', metavar='ID')
-        self.add_rpm_arguments(subcmd)
-        subcmd.set_defaults(func=self.rpm_update)
+        update_parser = self.add_admin_subcommand('update', help='update existing RPM')
+        update_parser.add_argument('rpmid', metavar='ID')
+        self.add_rpm_arguments(update_parser)
+        update_parser.set_defaults(func=self.rpm_update)
 
     def add_rpm_arguments(self, parser, required=False):
         required_args = {

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -73,9 +73,7 @@ class Runner(object):
     def setup(self):
         self.load_plugins()
 
-        self.parser = argparse.ArgumentParser(description='PDC Client')
-        self.parser.add_argument('--help-all', action='help',
-                                 help='show help including all commands')
+        self.parser = PDCArgumentParser(description='PDC Client')
         self.parser.add_argument('-s', '--server', default='stage',
                                  help='API URL or shortcut from config file')
         self.parser.add_argument('--debug', action='store_true', help=argparse.SUPPRESS)
@@ -124,3 +122,21 @@ class Runner(object):
                 print '{}:'.format(key)
                 for error in value:
                     print ' * {}'.format(error)
+
+
+class PDCArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        argparse.ArgumentParser.__init__(self, *args, **kwargs)
+        self.formatter_class = CommandHelpFormatter
+
+
+class CommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    '''
+    This is used to leave out the first line of help information in order to make it cleaner.
+    '''
+    def _format_action(self, action):
+        parts = super(argparse.RawDescriptionHelpFormatter, self)._format_action(action)
+        if action.nargs == argparse.PARSER:
+            parts = "\n".join(parts.split("\n")[1:])
+        return parts
+

--- a/pdc_client/tests/build_image/tests.py
+++ b/pdc_client/tests/build_image/tests.py
@@ -55,7 +55,7 @@ class BuildImageTestCase(CLITestCase):
     def test_list(self, api):
         self._setup_list_1(api)
         with self.expect_output('list_multi_page.txt'):
-            self.runner.run(['build-image-list'])
+            self.runner.run(['build-image', 'list'])
         self.assertEqual(api.calls['build-images'],
                          [('GET', {'page': 1}),
                           ('GET', {'page': 2})])
@@ -64,5 +64,5 @@ class BuildImageTestCase(CLITestCase):
         self._setup_detail(api)
         self._setup_list_2(api)
         with self.expect_output('detail.json', parse_json=True):
-            self.runner.run(['--json', 'build-image-info', 'test_image_1'])
+            self.runner.run(['--json', 'build-image', 'info', 'test_image_1'])
         self.assertEqual(api.calls['build-images'], [('GET', {'image_id': 'test_image_1'})])

--- a/pdc_client/tests/component/tests.py
+++ b/pdc_client/tests/component/tests.py
@@ -54,7 +54,7 @@ class GlobalComponentTestCase(CLITestCase):
 
     def test_list_without_filters(self, api):
         with self.expect_failure():
-            self.runner.run(['global-component-list'])
+            self.runner.run(['global-component', 'list'])
 
     def test_list_multi_page(self, api):
         api.add_endpoint('global-components', 'GET', [
@@ -63,7 +63,7 @@ class GlobalComponentTestCase(CLITestCase):
             for x in range(1, 26)
         ])
         with self.expect_output('global_component/list_multi_page.txt'):
-            self.runner.run(['global-component-list',
+            self.runner.run(['global-component', 'list',
                              '--label', 'test label'])
         self.assertEqual(api.calls['global-components'],
                          [('GET', {'page': 1, 'label': 'test label'}),
@@ -72,7 +72,7 @@ class GlobalComponentTestCase(CLITestCase):
     def test_detail(self, api):
         self._setup_detail(api)
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-info', '1'])
+            self.runner.run(['global-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('GET', {})]})
 
@@ -80,7 +80,7 @@ class GlobalComponentTestCase(CLITestCase):
         self._setup_detail(api)
         api.add_endpoint('global-components/1', 'PATCH', {})
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-update', '1', '--name', 'new test name'])
+            self.runner.run(['global-component', 'update', '1', '--name', 'new test name'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('PATCH', {'name': 'new test name'}),
                                                       ('GET', {})]})
@@ -89,7 +89,7 @@ class GlobalComponentTestCase(CLITestCase):
         api.add_endpoint('global-components', 'POST', self.detail)
         self._setup_detail(api)
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-create',
+            self.runner.run(['global-component', 'update',
                              '--name', 'Test Global Component',
                              '--dist-git-path', 'test_global_component'])
         self.assertDictEqual(api.calls,
@@ -100,14 +100,14 @@ class GlobalComponentTestCase(CLITestCase):
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('global_component/detail.json', parse_json=True):
-            self.runner.run(['--json', 'global-component-info', '1'])
+            self.runner.run(['--json', 'global-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('GET', {})]})
 
     def test_list_json(self, api):
         api.add_endpoint('global-components', 'GET', [self.detail])
         with self.expect_output('global_component/list.json', parse_json=True):
-            self.runner.run(['--json', 'global-component-list',
+            self.runner.run(['--json', 'global-component', 'list',
                              '--label', 'test label'])
 
 
@@ -155,7 +155,7 @@ class ReleaseComponentTestCase(CLITestCase):
 
     def test_list_without_filters(self, api):
         with self.expect_failure():
-            self.runner.run(['release-component-list'])
+            self.runner.run(['release-component', 'list'])
 
     def test_list_multi_page(self, api):
         api.add_endpoint('release-components', 'GET', [
@@ -166,7 +166,7 @@ class ReleaseComponentTestCase(CLITestCase):
             for x in range(1, 26)
         ])
         with self.expect_output('release_component/list_multi_page.txt'):
-            self.runner.run(['release-component-list',
+            self.runner.run(['release-component', 'list',
                              '--release', 'Test Release'])
         self.assertEqual(api.calls['release-components'],
                          [('GET', {'page': 1, 'release': 'Test Release'}),
@@ -175,7 +175,7 @@ class ReleaseComponentTestCase(CLITestCase):
     def test_detail(self, api):
         self._setup_detail(api)
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-info', '1'])
+            self.runner.run(['release-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('GET', {})]})
 
@@ -183,7 +183,7 @@ class ReleaseComponentTestCase(CLITestCase):
         self._setup_detail(api)
         api.add_endpoint('release-components/1', 'PATCH', {})
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-update', '1', '--name', 'new test name'])
+            self.runner.run(['release-component', 'update', '1', '--name', 'new test name'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('PATCH', {'name': 'new test name'}),
                                                        ('GET', {})]})
@@ -192,7 +192,7 @@ class ReleaseComponentTestCase(CLITestCase):
         api.add_endpoint('release-components', 'POST', self.detail)
         self._setup_detail(api)
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-create',
+            self.runner.run(['release-component', 'create',
                              '--name', 'Test Release Component',
                              '--release', 'test_release',
                              '--global-component', 'test_global_component'])
@@ -206,12 +206,12 @@ class ReleaseComponentTestCase(CLITestCase):
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('release_component/detail.json', parse_json=True):
-            self.runner.run(['--json', 'release-component-info', '1'])
+            self.runner.run(['--json', 'release-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('GET', {})]})
 
     def test_list_json(self, api):
         api.add_endpoint('release-components', 'GET', [self.detail])
         with self.expect_output('release_component/list.json', parse_json=True):
-            self.runner.run(['--json', 'release-component-list',
+            self.runner.run(['--json', 'release-component', 'list',
                              '--release', 'test_release'])


### PR DESCRIPTION
The original command structure goes like `pdc COMMAND` and now it looks like `pdc COMMAND SUB-COMMAND`. The functions of the original commands are not altered. 

JIRA: PDC-1129