### PR TITLE
Rename resource names

### DIFF
--- a/pdc/apps/contact/views.py
+++ b/pdc/apps/contact/views.py
@@ -25,6 +25,11 @@ class PersonViewSet(viewsets.PDCModelViewSet):
     You can use ``curl`` in terminal, with -X _method_ (GET|POST|PUT|PATCH|DELETE),
     -d _data_ (a json string). or GUI plugins for
     browsers, such as ``RESTClient``, ``RESTConsole``.
+
+    Please access this endpoint by
+    [%(HOST_NAME)s/%(API_PATH)s/contacts/people/](/%(API_PATH)s/contacts/people/).
+    Endpoint
+    [%(HOST_NAME)s/%(API_PATH)s/persons/](/%(API_PATH)s/persons/) is deprecated.
     """
 
     def create(self, request, *args, **kwargs):
@@ -152,7 +157,7 @@ class MaillistViewSet(viewsets.PDCModelViewSet):
     """
     ##Overview##
 
-    This page shows the usage of the **Maillist API**, please see the
+    This page shows the usage of the **Mailing list API**, please see the
     following for more details.
 
     ##Test tools##
@@ -160,6 +165,11 @@ class MaillistViewSet(viewsets.PDCModelViewSet):
     You can use ``curl`` in terminal, with -X _method_ (GET|POST|PUT|PATCH|DELETE),
     -d _data_ (a json string). or GUI plugins for
     browsers, such as ``RESTClient``, ``RESTConsole``.
+
+    Please access this endpoint by
+    [%(HOST_NAME)s/%(API_PATH)s/contacts/mailing-lists/](/%(API_PATH)s/contacts/mailing-lists/).
+    Endpoint
+    [%(HOST_NAME)s/%(API_PATH)s/maillists/](/%(API_PATH)s/maillists/) is deprecated.
     """
 
     def create(self, request, *args, **kwargs):

--- a/pdc/apps/repository/views.py
+++ b/pdc/apps/repository/views.py
@@ -307,6 +307,11 @@ class ContentCategoryViewSet(StrictQueryParamMixin,
                              viewsets.GenericViewSet):
     """
     API endpoint that allows content_category to be viewed.
+
+    Please access this endpoint by [%(HOST_NAME)s/%(API_PATH)s/content-delivery-content-categories/](/%(API_PATH)s/
+    content-delivery-content-categories/).
+    Endpoint [%(HOST_NAME)s/%(API_PATH)s/content-delivery-content-category/](/%(API_PATH)s/
+    content-delivery-content-category/) is deprecated.
     """
     serializer_class = serializers.ContentCategorySerializer
     queryset = models.ContentCategory.objects.all()
@@ -329,6 +334,12 @@ class ContentFormatViewSet(StrictQueryParamMixin,
                            viewsets.GenericViewSet):
     """
     API endpoint that allows content_format to be viewed.
+
+    Please access this endpoint by
+    [%(HOST_NAME)s/%(API_PATH)s/content-delivery-content-formats/](/%(API_PATH)s/content-delivery-content-formats/).
+    Endpoint
+    [%(HOST_NAME)s/%(API_PATH)s/content-delivery-content-format/](/%(API_PATH)s/content-delivery-content-format/)
+    is deprecated.
     """
     serializer_class = serializers.ContentFormatSerializer
     queryset = models.ContentFormat.objects.all()
@@ -351,6 +362,11 @@ class ServiceViewSet(StrictQueryParamMixin,
                      viewsets.GenericViewSet):
     """
     API endpoint that allows service to be viewed.
+
+    Please access this endpoint by
+    [%(HOST_NAME)s/%(API_PATH)s/content-delivery-services/](/%(API_PATH)s/content-delivery-services/).
+    Endpoint
+    [%(HOST_NAME)s/%(API_PATH)s/content-delivery-service/](/%(API_PATH)s/content-delivery-service/) is deprecated.
     """
     serializer_class = serializers.ServiceSerializer
     queryset = models.Service.objects.all()

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -39,8 +39,8 @@ router.register(r'base-products', release_views.BaseProductViewSet)
 router.register(r'release-types', release_views.ReleaseTypeViewSet, base_name='releasetype')
 
 # TODO: these two end-points will be removed
-router.register(r'persons', contact_views.PersonViewSet, base_name='persondeperated')
-router.register(r'maillists', contact_views.MaillistViewSet, base_name='maillistdeperated')
+router.register(r'persons', contact_views.PersonViewSet, base_name='persondeprecated')
+router.register(r'maillists', contact_views.MaillistViewSet, base_name='maillistdeprecated')
 
 # register contact view sets
 router.register(r'contacts/people', contact_views.PersonViewSet, base_name='person')

--- a/pdc/routers.py
+++ b/pdc/routers.py
@@ -38,9 +38,13 @@ router.register(r'releases', release_views.ReleaseViewSet)
 router.register(r'base-products', release_views.BaseProductViewSet)
 router.register(r'release-types', release_views.ReleaseTypeViewSet, base_name='releasetype')
 
+# TODO: these two end-points will be removed
+router.register(r'persons', contact_views.PersonViewSet, base_name='persondeperated')
+router.register(r'maillists', contact_views.MaillistViewSet, base_name='maillistdeperated')
+
 # register contact view sets
-router.register(r'persons', contact_views.PersonViewSet)
-router.register(r'maillists', contact_views.MaillistViewSet)
+router.register(r'contacts/people', contact_views.PersonViewSet, base_name='person')
+router.register(r'contacts/mailing-lists', contact_views.MaillistViewSet, base_name='maillist')
 router.register(r'contact-roles', contact_views.ContactRoleViewSet)
 router.register(r'role-contacts', contact_views.RoleContactViewSet)
 
@@ -147,11 +151,20 @@ router.register(r'release-variants',
                 release_views.ReleaseVariantViewSet)
 router.register(r'variant-types', release_views.VariantTypeViewSet,
                 base_name='varianttype')
+
+# TODO: these three end-points will be removed
 router.register(r'content-delivery-content-category', repo_views.ContentCategoryViewSet,
-                base_name='contentdeliverycontentcategory')
+                base_name='contentcategorydeprecated')
 router.register(r'content-delivery-content-format', repo_views.ContentFormatViewSet,
-                base_name='contentdeliverycontentformat')
+                base_name='contentformatdeprecated')
 router.register(r'content-delivery-service', repo_views.ServiceViewSet,
+                base_name='contentservicedeprecated')
+
+router.register(r'content-delivery-content-categories', repo_views.ContentCategoryViewSet,
+                base_name='contentdeliverycontentcategory')
+router.register(r'content-delivery-content-formats', repo_views.ContentFormatViewSet,
+                base_name='contentdeliverycontentformat')
+router.register(r'content-delivery-services', repo_views.ServiceViewSet,
                 base_name='contentdeliveryservice')
 
 router.register(r'osbs', osbs_views.OSBSViewSet,


### PR DESCRIPTION
To be consistent with other end-points, rename below three ones:
* content-delivery-content-category -> content-delivery-content-categories
* content-delivery-content-format -> content-delivery-content-formats
* content-delivery-service -> content-delivery-services
The old names remain available for backwards compatibility, but has been
marked deprecated.

JIRA: PDC-1027