### PR TITLE
Restructure pdc client command structure

### DIFF
--- a/pdc_client/plugin_helpers.py
+++ b/pdc_client/plugin_helpers.py
@@ -33,7 +33,6 @@
 #
 
 import logging
-import sys
 
 
 DATA_PREFIX = 'data__'
@@ -47,7 +46,6 @@ class PDCClientPlugin(object):
     def __init__(self, runner):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.runner = runner
-        self.help_all = '--help-all' in sys.argv
 
     @property
     def client(self):
@@ -62,22 +60,18 @@ class PDCClientPlugin(object):
     def register(self):
         raise NotImplementedError('Plugin must implement `register` method.')
 
-    def add_command(self, *args, **kwargs):
-        """Define new subcommand.
+    def set_command(self, *args, **kwargs):
+        """Define new command.
 
         For accepted arguments, see `argparse.ArgumentParser.add_argument`.
         """
-        return self.parser.add_parser(*args, **kwargs)
+        if 'help' not in kwargs:
+            kwargs['help'] = ''
+        cmd = self.parser.add_parser(*args, **kwargs)
+        self.subparsers = cmd.add_subparsers(metavar='ACTION')
 
-    def add_admin_command(self, *args, **kwargs):
-        """Define new admin subcommand.
-
-        Help of this subcommand will be hidden for regular --help option, but
-        will show when --help-all is used. Otherwise identical to add_command.
-        """
-        if not self.help_all:
-            kwargs.pop('help', None)
-        return self.parser.add_parser(*args, **kwargs)
+    def add_action(self, *args, **kwargs):
+        return self.subparsers.add_parser(*args, **kwargs)
 
 
 def add_parser_arguments(parser, args, group=None, prefix=DATA_PREFIX):

--- a/pdc_client/plugins/build_images.py
+++ b/pdc_client/plugins/build_images.py
@@ -13,27 +13,28 @@ from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, ext
 
 class BuildImagePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('build-image-list', help='list all build images')
-        subcmd.add_argument('--show-md5', action='store_true',
-                            help='whether to display md5 checksums')
-        add_parser_arguments(subcmd, {'component_name': {},
-                                      'rpm_version': {},
-                                      'rpm_release': {},
-                                      'image_id': {},
-                                      'image_format': {},
-                                      'md5': {},
-                                      'archive_build_nvr': {},
-                                      'archive_name': {},
-                                      'archive_size': {},
-                                      'archive_md5': {},
-                                      'release_id': {}},
+        self.set_command('build-image')
+
+        list_parser = self.add_action('list', help='list all build images')
+        list_parser.add_argument('--show-md5', action='store_true',
+                                 help='whether to display md5 checksums')
+        add_parser_arguments(list_parser, {'component_name': {},
+                                           'rpm_version': {},
+                                           'rpm_release': {},
+                                           'image_id': {},
+                                           'image_format': {},
+                                           'md5': {},
+                                           'archive_build_nvr': {},
+                                           'archive_name': {},
+                                           'archive_size': {},
+                                           'archive_md5': {},
+                                           'release_id': {}},
                              group='Filtering')
+        list_parser.set_defaults(func=self.list_build_image)
 
-        subcmd.set_defaults(func=self.list_build_image)
-
-        subcmd = self.add_command('build-image-info', help='display details of a build image')
-        subcmd.add_argument('image_id', metavar='IMAGE_ID')
-        subcmd.set_defaults(func=self.build_image_info)
+        info_parser = self.add_action('info', help='display details of a build image')
+        info_parser.add_argument('image_id', metavar='IMAGE_ID')
+        info_parser.set_defaults(func=self.build_image_info)
 
     def _print_build_image_list(self, build_images, with_md5=False):
         fmt = '{image_id}'

--- a/pdc_client/plugins/component.py
+++ b/pdc_client/plugins/component.py
@@ -16,27 +16,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class GlobalComponentPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('global-component-list', help='list all global components')
+        self.set_command('global-component')
+
+        list_parser = self.add_action('list', help='list all global components')
         filters = ('dist_git_path contact_role email label name upstream_homepage upstream_scm_type '
                    'upstream_scm_url'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
-        subcmd.set_defaults(func=self.list_global_components)
+            list_parser.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
+        list_parser.set_defaults(func=self.list_global_components)
 
-        subcmd = self.add_command('global-component-info', help='display details of a global component')
-        subcmd.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
-        subcmd.set_defaults(func=self.global_component_info)
+        info_parser = self.add_action('info', help='display details of a global component')
+        info_parser.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
+        info_parser.set_defaults(func=self.global_component_info)
 
-        subcmd = self.add_admin_command('global-component-update',
-                                        help='update an existing global component')
-        subcmd.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
-        self.add_global_component_arguments(subcmd)
-        subcmd.set_defaults(func=self.global_component_update)
+        update_parser = self.add_action('update', help='update an existing global component')
+        update_parser.add_argument('global_component_id', metavar='GLOBAL_COMPONENT_ID')
+        self.add_global_component_arguments(update_parser)
+        update_parser.set_defaults(func=self.global_component_update)
 
-        subcmd = self.add_admin_command('global-component-create',
-                                        help='create new global component')
-        self.add_global_component_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.global_component_create)
+        create_parser = self.add_action('create', help='create new global component')
+        self.add_global_component_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.global_component_create)
 
     def add_global_component_arguments(self, parser, required=False):
         add_create_update_args(parser,
@@ -117,31 +117,31 @@ class GlobalComponentPlugin(PDCClientPlugin):
 
 class ReleaseComponentPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('release-component-list', help='list all release components')
-        self.add_include_inactive_release_argument(subcmd)
+        self.set_command('release-component')
+
+        list_parser = self.add_action('list', help='list all release components')
+        self.add_include_inactive_release_argument(list_parser)
         filters = ('active brew_package bugzilla_component contact_role email global_component name release srpm_name '
                    'type'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
-        subcmd.set_defaults(func=self.list_release_components)
+            list_parser.add_argument('--' + arg.replace('_', '-'), dest='filter_' + arg)
+        list_parser.set_defaults(func=self.list_release_components)
 
-        subcmd = self.add_command('release-component-info', help='display details of a release component')
-        self.add_include_inactive_release_argument(subcmd)
-        subcmd.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
-        subcmd.set_defaults(func=self.release_component_info)
+        info_parser = self.add_action('info', help='display details of a release component')
+        self.add_include_inactive_release_argument(info_parser)
+        info_parser.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
+        info_parser.set_defaults(func=self.release_component_info)
 
-        subcmd = self.add_admin_command('release-component-update',
-                                        help='update an existing release component')
-        subcmd.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
-        self.add_release_component_arguments(subcmd)
-        subcmd.set_defaults(func=self.release_component_update)
+        update_parser = self.add_action('update', help='update an existing release component')
+        update_parser.add_argument('release_component_id', metavar='RELEASE_COMPONENT_ID')
+        self.add_release_component_arguments(update_parser)
+        update_parser.set_defaults(func=self.release_component_update)
 
-        subcmd = self.add_admin_command('release-component-create',
-                                        help='create new release')
-        self.add_release_component_arguments(subcmd, required=True)
-        subcmd.add_argument('--release', dest='release', required=True)
-        subcmd.add_argument('--global-component', dest='global_component', required=True)
-        subcmd.set_defaults(func=self.release_component_create)
+        create_parser = self.add_action('create', help='create new release component')
+        self.add_release_component_arguments(create_parser, required=True)
+        create_parser.add_argument('--release', dest='release', required=True)
+        create_parser.add_argument('--global-component', dest='global_component', required=True)
+        create_parser.set_defaults(func=self.release_component_create)
 
     def add_include_inactive_release_argument(self, parser):
         parser.add_argument('--include-inactive-release', action='store_true',

--- a/pdc_client/plugins/compose.py
+++ b/pdc_client/plugins/compose.py
@@ -12,29 +12,32 @@ from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, ext
 
 class ComposePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('compose-list', help='list all composes')
-        subcmd.add_argument('--deleted', action='store_true',
-                            help='show deleted composes')
-        subcmd.set_defaults(func=self.list_composes)
+        self.set_command('compose')
 
-        subcmd = self.add_command('compose-info', help='display details of a compose')
-        subcmd.add_argument('compose_id', metavar='COMPOSE_ID')
-        subcmd.set_defaults(func=self.compose_info)
+        list_parser = self.add_action('list', help='list all composes')
+        list_parser.add_argument('--deleted', action='store_true',
+                                 help='show deleted composes')
+        list_parser.set_defaults(func=self.list_composes)
 
-        subcmd = self.add_admin_command('compose-update',
+        info_parser = self.add_action('info', help='display details of a compose')
+        info_parser.add_argument('compose_id', metavar='COMPOSE_ID')
+        info_parser.set_defaults(func=self.compose_info)
+
+        update_parser = self.add_action('update',
                                         help='partial update an existing compose.',
                                         description='only some compose fields can be modified by this call.\
-                                                    these are acceptance_testing, linked_releases and rtt_tested_architectures.')
-        subcmd.add_argument('compose_id', metavar='COMPOSE_ID')
-        self.add_compose_arguments(subcmd)
-        subcmd.set_defaults(func=self.compose_update)
-        self.compose_update = subcmd
+                                            these are acceptance_testing, linked_releases and rtt_tested_architectures.')
+        update_parser.add_argument('compose_id', metavar='COMPOSE_ID')
+        self.add_compose_arguments(update_parser)
+        update_parser.set_defaults(func=self.compose_update)
+        self.compose_update = update_parser
 
     def add_compose_arguments(self, parser):
         add_parser_arguments(parser, {
             'acceptance_testing': {'choices': ['passed', 'failed', 'untested']},
             'linked_releases': {'nargs': '*', 'metavar': 'RELEASE_ID'},
-            'rtt_tested_architectures': {'nargs': '*', 'default': [], 'help': 'input format VARIANT:ARCHES:TESTING_STATUS'}})
+            'rtt_tested_architectures': {'nargs': '*', 'default': [],
+                                         'help': 'input format VARIANT:ARCHES:TESTING_STATUS'}})
 
     def list_composes(self, args):
         filters = {}
@@ -64,7 +67,7 @@ class ComposePlugin(PDCClientPlugin):
         print fmt.format('Compose Date', compose['compose_date'])
         print fmt.format('Compose Respin', compose['compose_respin'])
         print fmt.format('Compose Type', compose['compose_type'])
-        print fmt. format('Acceptance Testing', compose['acceptance_testing'])
+        print fmt.format('Acceptance Testing', compose['acceptance_testing'])
         print fmt.format('Deleted', compose['deleted'])
         print fmt.format('Release', compose['release'])
         print fmt.format('Rpm Mapping Template', compose['rpm_mapping_template'])
@@ -106,7 +109,8 @@ class ComposePlugin(PDCClientPlugin):
         for rtt in rtts:
             parts = rtt.split(':')
             if not len(parts) == 3:
-                self.compose_update.error('Please input rtt-tested-architectures in format VARIANT:ARCHES:TESTING_STATUS.\n')
+                self.compose_update.error(
+                    'Please input rtt-tested-architectures in format VARIANT:ARCHES:TESTING_STATUS.\n')
 
             variant = parts[0]
             arches = parts[1]
@@ -116,5 +120,6 @@ class ComposePlugin(PDCClientPlugin):
         data['rtt_tested_architectures'] = dic
 
         return data
+
 
 PLUGIN_CLASSES = [ComposePlugin]

--- a/pdc_client/plugins/image.py
+++ b/pdc_client/plugins/image.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from pdc_client import get_paged
 from pdc_client.plugin_helpers import PDCClientPlugin, add_parser_arguments, extract_arguments
 
-
 info_desc = """Generally there may be duplicate file names. If the file name
 you provide matches more that image, you will get a list of all those images
 together with their SHA256 checksums. You desambiguate by providing the
@@ -31,27 +30,28 @@ def size_format(num):
 
 class ImagePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('image-list', help='list all images')
-        subcmd.add_argument('--show-sha256', action='store_true',
-                            help='whether to display SHA256 checksums along with the file names')
-        add_parser_arguments(subcmd, {'arch': {},
-                                      'compose': {},
-                                      'file_name': {},
-                                      'image_format': {},
-                                      'image_type': {},
-                                      'implant_md5': {},
-                                      'md5': {},
-                                      'sha1': {},
-                                      'sha256': {},
-                                      'volume_id': {}},
-                             group='Filtering')
-        subcmd.set_defaults(func=self.image_list)
+        self.set_command('image')
 
-        subcmd = self.add_command('image-info', help='display details of an image',
-                                  description=info_desc)
-        subcmd.add_argument('filename', metavar='FILENAME')
-        subcmd.add_argument('--sha256', nargs='?')
-        subcmd.set_defaults(func=self.image_info)
+        list_parser = self.add_action('list', help='list all images')
+        list_parser.add_argument('--show-sha256', action='store_true',
+                                 help='whether to display SHA256 checksums along with the file names')
+        add_parser_arguments(list_parser, {'arch': {},
+                                           'compose': {},
+                                           'file_name': {},
+                                           'image_format': {},
+                                           'image_type': {},
+                                           'implant_md5': {},
+                                           'md5': {},
+                                           'sha1': {},
+                                           'sha256': {},
+                                           'volume_id': {}},
+                             group='Filtering')
+        list_parser.set_defaults(func=self.image_list)
+
+        info_parser = self.add_action('info', help='display details of an image', description=info_desc)
+        info_parser.add_argument('filename', metavar='FILENAME')
+        info_parser.add_argument('--sha256', nargs='?')
+        info_parser.set_defaults(func=self.image_info)
 
     def _print_image_list(self, images, with_sha=False):
         fmt = '{file_name}'
@@ -110,5 +110,6 @@ class ImagePlugin(PDCClientPlugin):
                 print '\nUsed in composes:'
                 for compose in image['composes']:
                     print ' * {}'.format(compose)
+
 
 PLUGIN_CLASSES = [ImagePlugin]

--- a/pdc_client/plugins/permission.py
+++ b/pdc_client/plugins/permission.py
@@ -11,8 +11,10 @@ from pdc_client.plugin_helpers import PDCClientPlugin
 
 class PermissionPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('list-my-permissions', help='list my permissions')
-        subcmd.set_defaults(func=self.permission_list)
+        self.set_command('permission')
+
+        list_parser = self.add_action('list', help='list my permissions')
+        list_parser.set_defaults(func=self.permission_list)
 
     def permission_list(self, args):
         permissions = self.__get_permissions(self.client.auth['current-user'])

--- a/pdc_client/plugins/release.py
+++ b/pdc_client/plugins/release.py
@@ -14,27 +14,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class ReleasePlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('release-list', help='list all releases')
-        subcmd.add_argument('--inactive', action='store_true',
-                            help='show only inactive releases')
-        subcmd.add_argument('--all', action='store_true',
-                            help='show both active and inactive releases')
-        subcmd.set_defaults(func=self.list_releases)
+        self.set_command('release')
 
-        subcmd = self.add_command('release-info', help='display details of a release')
-        subcmd.add_argument('release_id', metavar='RELEASE_ID')
-        subcmd.set_defaults(func=self.release_info)
+        list_parser = self.add_action('list', help='list all releases')
+        list_parser.add_argument('--inactive', action='store_true',
+                                 help='show only inactive releases')
+        list_parser.add_argument('--all', action='store_true',
+                                 help='show both active and inactive releases')
+        list_parser.set_defaults(func=self.list_releases)
 
-        subcmd = self.add_admin_command('release-update',
-                                        help='update an existing release')
-        subcmd.add_argument('release_id', metavar='RELEASE_ID')
-        self.add_release_arguments(subcmd)
-        subcmd.set_defaults(func=self.release_update)
+        info_parser = self.add_action('info', help='display details of a release')
+        info_parser.add_argument('release_id', metavar='RELEASE_ID')
+        info_parser.set_defaults(func=self.release_info)
 
-        subcmd = self.add_admin_command('release-create',
-                                        help='create new release')
-        self.add_release_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.release_create)
+        update_parser = self.add_action('update', help='update an existing release')
+        update_parser.add_argument('release_id', metavar='RELEASE_ID')
+        self.add_release_arguments(update_parser)
+        update_parser.set_defaults(func=self.release_update)
+
+        create_parser = self.add_action('create', help='create new release')
+        self.add_release_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.release_create)
 
     def add_release_arguments(self, parser, required=False):
         group = parser.add_mutually_exclusive_group()

--- a/pdc_client/plugins/rpm.py
+++ b/pdc_client/plugins/rpm.py
@@ -16,27 +16,27 @@ from pdc_client.plugin_helpers import (PDCClientPlugin,
 
 class RPMPlugin(PDCClientPlugin):
     def register(self):
-        subcmd = self.add_command('rpm-list', help='list all rpms')
+        self.set_command('rpm')
+
+        list_parser = self.add_action('list', help='list all rpms')
         filters = ('name version release arch compose conflicts obsoletes provides '
                    'suggests recommends requires'.split())
         for arg in filters:
-            subcmd.add_argument('--' + arg, dest='filter_' + arg)
-        subcmd.set_defaults(func=self.rpm_list)
+            list_parser.add_argument('--' + arg, dest='filter_' + arg)
+        list_parser.set_defaults(func=self.rpm_list)
 
-        subcmd = self.add_command('rpm-info', help='display details of an RPM')
-        subcmd.add_argument('rpmid', metavar='ID')
-        subcmd.set_defaults(func=self.rpm_info)
+        info_parser = self.add_action('info', help='display details of an RPM')
+        info_parser.add_argument('rpmid', metavar='ID')
+        info_parser.set_defaults(func=self.rpm_info)
 
-        subcmd = self.add_admin_command('rpm-create',
-                                        help='create new RPM')
-        self.add_rpm_arguments(subcmd, required=True)
-        subcmd.set_defaults(func=self.rpm_create)
+        create_parser = self.add_action('create', help='create new RPM')
+        self.add_rpm_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.rpm_create)
 
-        subcmd = self.add_admin_command('rpm-update',
-                                        help='update existing RPM')
-        subcmd.add_argument('rpmid', metavar='ID')
-        self.add_rpm_arguments(subcmd)
-        subcmd.set_defaults(func=self.rpm_update)
+        update_parser = self.add_action('update', help='update existing RPM')
+        update_parser.add_argument('rpmid', metavar='ID')
+        self.add_rpm_arguments(update_parser)
+        update_parser.set_defaults(func=self.rpm_update)
 
     def add_rpm_arguments(self, parser, required=False):
         required_args = {

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -74,8 +74,6 @@ class Runner(object):
         self.load_plugins()
 
         self.parser = argparse.ArgumentParser(description='PDC Client')
-        self.parser.add_argument('--help-all', action='help',
-                                 help='show help including all commands')
         self.parser.add_argument('-s', '--server', default='stage',
                                  help='API URL or shortcut from config file')
         self.parser.add_argument('--debug', action='store_true', help=argparse.SUPPRESS)

--- a/pdc_client/tests/build_image/tests.py
+++ b/pdc_client/tests/build_image/tests.py
@@ -55,7 +55,7 @@ class BuildImageTestCase(CLITestCase):
     def test_list(self, api):
         self._setup_list_1(api)
         with self.expect_output('list_multi_page.txt'):
-            self.runner.run(['build-image-list'])
+            self.runner.run(['build-image', 'list'])
         self.assertEqual(api.calls['build-images'],
                          [('GET', {'page': 1}),
                           ('GET', {'page': 2})])
@@ -64,5 +64,5 @@ class BuildImageTestCase(CLITestCase):
         self._setup_detail(api)
         self._setup_list_2(api)
         with self.expect_output('detail.json', parse_json=True):
-            self.runner.run(['--json', 'build-image-info', 'test_image_1'])
+            self.runner.run(['--json', 'build-image', 'info', 'test_image_1'])
         self.assertEqual(api.calls['build-images'], [('GET', {'image_id': 'test_image_1'})])

--- a/pdc_client/tests/component/tests.py
+++ b/pdc_client/tests/component/tests.py
@@ -54,7 +54,7 @@ class GlobalComponentTestCase(CLITestCase):
 
     def test_list_without_filters(self, api):
         with self.expect_failure():
-            self.runner.run(['global-component-list'])
+            self.runner.run(['global-component', 'list'])
 
     def test_list_multi_page(self, api):
         api.add_endpoint('global-components', 'GET', [
@@ -63,7 +63,7 @@ class GlobalComponentTestCase(CLITestCase):
             for x in range(1, 26)
         ])
         with self.expect_output('global_component/list_multi_page.txt'):
-            self.runner.run(['global-component-list',
+            self.runner.run(['global-component', 'list',
                              '--label', 'test label'])
         self.assertEqual(api.calls['global-components'],
                          [('GET', {'page': 1, 'label': 'test label'}),
@@ -72,7 +72,7 @@ class GlobalComponentTestCase(CLITestCase):
     def test_detail(self, api):
         self._setup_detail(api)
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-info', '1'])
+            self.runner.run(['global-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('GET', {})]})
 
@@ -80,7 +80,7 @@ class GlobalComponentTestCase(CLITestCase):
         self._setup_detail(api)
         api.add_endpoint('global-components/1', 'PATCH', {})
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-update', '1', '--name', 'new test name'])
+            self.runner.run(['global-component', 'update', '1', '--name', 'new test name'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('PATCH', {'name': 'new test name'}),
                                                       ('GET', {})]})
@@ -89,7 +89,7 @@ class GlobalComponentTestCase(CLITestCase):
         api.add_endpoint('global-components', 'POST', self.detail)
         self._setup_detail(api)
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component-create',
+            self.runner.run(['global-component', 'create',
                              '--name', 'Test Global Component',
                              '--dist-git-path', 'test_global_component'])
         self.assertDictEqual(api.calls,
@@ -100,14 +100,14 @@ class GlobalComponentTestCase(CLITestCase):
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('global_component/detail.json', parse_json=True):
-            self.runner.run(['--json', 'global-component-info', '1'])
+            self.runner.run(['--json', 'global-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'global-components/1': [('GET', {})]})
 
     def test_list_json(self, api):
         api.add_endpoint('global-components', 'GET', [self.detail])
         with self.expect_output('global_component/list.json', parse_json=True):
-            self.runner.run(['--json', 'global-component-list',
+            self.runner.run(['--json', 'global-component', 'list',
                              '--label', 'test label'])
 
 
@@ -155,7 +155,7 @@ class ReleaseComponentTestCase(CLITestCase):
 
     def test_list_without_filters(self, api):
         with self.expect_failure():
-            self.runner.run(['release-component-list'])
+            self.runner.run(['release-component', 'list'])
 
     def test_list_multi_page(self, api):
         api.add_endpoint('release-components', 'GET', [
@@ -166,7 +166,7 @@ class ReleaseComponentTestCase(CLITestCase):
             for x in range(1, 26)
         ])
         with self.expect_output('release_component/list_multi_page.txt'):
-            self.runner.run(['release-component-list',
+            self.runner.run(['release-component', 'list',
                              '--release', 'Test Release'])
         self.assertEqual(api.calls['release-components'],
                          [('GET', {'page': 1, 'release': 'Test Release'}),
@@ -175,7 +175,7 @@ class ReleaseComponentTestCase(CLITestCase):
     def test_detail(self, api):
         self._setup_detail(api)
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-info', '1'])
+            self.runner.run(['release-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('GET', {})]})
 
@@ -183,7 +183,7 @@ class ReleaseComponentTestCase(CLITestCase):
         self._setup_detail(api)
         api.add_endpoint('release-components/1', 'PATCH', {})
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-update', '1', '--name', 'new test name'])
+            self.runner.run(['release-component', 'update', '1', '--name', 'new test name'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('PATCH', {'name': 'new test name'}),
                                                        ('GET', {})]})
@@ -192,7 +192,7 @@ class ReleaseComponentTestCase(CLITestCase):
         api.add_endpoint('release-components', 'POST', self.detail)
         self._setup_detail(api)
         with self.expect_output('release_component/detail.txt'):
-            self.runner.run(['release-component-create',
+            self.runner.run(['release-component', 'create',
                              '--name', 'Test Release Component',
                              '--release', 'test_release',
                              '--global-component', 'test_global_component'])
@@ -206,12 +206,12 @@ class ReleaseComponentTestCase(CLITestCase):
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('release_component/detail.json', parse_json=True):
-            self.runner.run(['--json', 'release-component-info', '1'])
+            self.runner.run(['--json', 'release-component', 'info', '1'])
         self.assertDictEqual(api.calls,
                              {'release-components/1': [('GET', {})]})
 
     def test_list_json(self, api):
         api.add_endpoint('release-components', 'GET', [self.detail])
         with self.expect_output('release_component/list.json', parse_json=True):
-            self.runner.run(['--json', 'release-component-list',
+            self.runner.run(['--json', 'release-component', 'list',
                              '--release', 'test_release'])

--- a/pdc_client/tests/compose/tests.py
+++ b/pdc_client/tests/compose/tests.py
@@ -41,7 +41,7 @@ class ComposeTestCase(CLITestCase):
             for x in range(23)
         ])
         with self.expect_output('list_multi_page.txt'):
-            self.runner.run(['compose-list'])
+            self.runner.run(['compose', 'list'])
         self.assertEqual(api.calls['composes'],
                          [('GET', {'page': 1, 'deleted': False}),
                           ('GET', {'page': 2, 'deleted': False})])
@@ -49,21 +49,21 @@ class ComposeTestCase(CLITestCase):
     def test_list_deleted(self, api):
         api.add_endpoint('composes', 'GET', [])
         with self.expect_output('empty.txt'):
-            self.runner.run(['compose-list', '--deleted'])
+            self.runner.run(['compose', 'list', '--deleted'])
         self.assertEqual(api.calls['composes'],
                          [('GET', {'page': 1, 'deleted': True})])
 
     def test_info(self, api):
         api.add_endpoint('composes/awesome-product-20130203.7', 'GET', self.compose_detail)
         with self.expect_output('info.txt'):
-            self.runner.run(['compose-info', 'awesome-product-20130203.7'])
+            self.runner.run(['compose', 'info', 'awesome-product-20130203.7'])
         self.assertDictEqual(api.calls,
                              {'composes/awesome-product-20130203.7': [('GET', {})]})
 
     def test_info_json(self, api):
         api.add_endpoint('composes/awesome-product-20130203.7', 'GET', self.compose_detail)
         with self.expect_output('info.json', parse_json=True):
-            self.runner.run(['--json', 'compose-info', 'awesome-product-20130203.7'])
+            self.runner.run(['--json', 'compose', 'info', 'awesome-product-20130203.7'])
         self.assertDictEqual(api.calls,
                              {'composes/awesome-product-20130203.7': [('GET', {})]})
 
@@ -71,7 +71,7 @@ class ComposeTestCase(CLITestCase):
         api.add_endpoint('composes/awesome-product-20130203.7', 'GET', self.compose_detail)
         api.add_endpoint('composes/awesome-product-20130203.7', 'PATCH', {})
         with self.expect_output('info.txt'):
-            self.runner.run(['compose-update', 'awesome-product-20130203.7',
+            self.runner.run(['compose', 'update', 'awesome-product-20130203.7',
                              '--acceptance-testing', 'passed',
                              '--linked-releases', 'sap-7.0-awesome-product',
                              '--rtt-tested-architectures', 'Workstation:x86_64:passed'
@@ -84,7 +84,7 @@ class ComposeTestCase(CLITestCase):
 
     def test_update_wrong_input1(self, api):
         with self.expect_failure():
-            self.runner.run(['compose-update', 'awesome-product-20130203.7',
+            self.runner.run(['compose', 'update', 'awesome-product-20130203.7',
                              '--acceptance-testing', 'passed',
                              '--linked-releases', 'sap-7.0-awesome-product',
                              '--rtt-tested-architectures', 'Workstation:x86_64:passed:wronginput'
@@ -92,7 +92,7 @@ class ComposeTestCase(CLITestCase):
 
     def test_update_wrong_input2(self, api):
         with self.expect_failure():
-            self.runner.run(['compose-update', 'awesome-product-20130203.7',
+            self.runner.run(['compose', 'update', 'awesome-product-20130203.7',
                              '--acceptance-testing', 'wronginput',
                              '--linked-releases', 'sap-7.0-awesome-product',
                              '--rtt-tested-architectures', 'Workstation:x86_64:passed'

--- a/pdc_client/tests/image/tests.py
+++ b/pdc_client/tests/image/tests.py
@@ -74,7 +74,7 @@ class ImageTestCase(CLITestCase):
     def test_list(self, api):
         self._setup_list(api)
         with self.expect_output('list_multi_page.txt'):
-            self.runner.run(['image-list'])
+            self.runner.run(['image', 'list'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'page': 1}),
                           ('GET', {'page': 2})])
@@ -82,7 +82,7 @@ class ImageTestCase(CLITestCase):
     def test_list_json(self, api):
         self._setup_list(api)
         with self.expect_output('list_multi_page.json', parse_json=True):
-            self.runner.run(['--json', 'image-list'])
+            self.runner.run(['--json', 'image', 'list'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'page': 1}),
                           ('GET', {'page': 2})])
@@ -93,7 +93,7 @@ class ImageTestCase(CLITestCase):
                    'file-name', 'image-format', 'arch', 'md5', 'implant-md5']
         for filter in filters:
             with self.expect_output('empty.txt'):
-                self.runner.run(['image-list', '--' + filter, filter])
+                self.runner.run(['image', 'list', '--' + filter, filter])
         self.assertEqual(api.calls['images'],
                          [('GET', {'page': 1, filter.replace('-', '_'): filter})
                           for filter in filters])
@@ -101,7 +101,7 @@ class ImageTestCase(CLITestCase):
     def test_show_sha256(self, api):
         self._setup_list(api)
         with self.expect_output('list_multi_page_with_sha256.txt'):
-            self.runner.run(['image-list', '--show-sha256'])
+            self.runner.run(['image', 'list', '--show-sha256'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'page': 1}),
                           ('GET', {'page': 2})])
@@ -109,14 +109,14 @@ class ImageTestCase(CLITestCase):
     def test_info(self, api):
         self._setup_detail(api)
         with self.expect_output('info.txt'):
-            self.runner.run(['image-info', 'unique_filename.iso'])
+            self.runner.run(['image', 'info', 'unique_filename.iso'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'file_name': 'unique_filename.iso'})])
 
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('info.json', parse_json=True):
-            self.runner.run(['--json', 'image-info', 'unique_filename.iso'])
+            self.runner.run(['--json', 'image', 'info', 'unique_filename.iso'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'file_name': 'unique_filename.iso'})])
 
@@ -124,14 +124,14 @@ class ImageTestCase(CLITestCase):
         self._setup_duplicit_detail(api)
         with self.expect_output('duplicit.txt'):
             with self.expect_failure():
-                self.runner.run(['image-info', 'unique_filename.iso'])
+                self.runner.run(['image', 'info', 'unique_filename.iso'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'file_name': 'unique_filename.iso'})])
 
     def test_info_with_sha(self, api):
         self._setup_detail(api)
         with self.expect_output('info.txt'):
-            self.runner.run(['image-info', 'unique_filename.iso',
+            self.runner.run(['image', 'info', 'unique_filename.iso',
                              '--sha256', '3333333333333333333333333333333333333333333333333333333333333333'])
         self.assertEqual(api.calls['images'],
                          [('GET', {'file_name': 'unique_filename.iso',

--- a/pdc_client/tests/release/tests.py
+++ b/pdc_client/tests/release/tests.py
@@ -42,7 +42,7 @@ class ReleaseTestCase(CLITestCase):
             for x in range(25)
         ])
         with self.expect_output('list_multi_page.txt'):
-            self.runner.run(['release-list'])
+            self.runner.run(['release', 'list'])
         self.assertEqual(api.calls['releases'],
                          [('GET', {'page': 1, 'active': True}),
                           ('GET', {'page': 2, 'active': True})])
@@ -50,21 +50,21 @@ class ReleaseTestCase(CLITestCase):
     def test_list_inactive(self, api):
         api.add_endpoint('releases', 'GET', [])
         with self.expect_output('empty.txt'):
-            self.runner.run(['release-list', '--inactive'])
+            self.runner.run(['release', 'list', '--inactive'])
         self.assertEqual(api.calls['releases'],
                          [('GET', {'page': 1, 'active': False})])
 
     def test_list_all(self, api):
         api.add_endpoint('releases', 'GET', [])
         with self.expect_output('empty.txt'):
-            self.runner.run(['release-list', '--all'])
+            self.runner.run(['release', 'list', '--all'])
         self.assertEqual(api.calls['releases'],
                          [('GET', {'page': 1})])
 
     def test_detail(self, api):
         self._setup_release_detail(api)
         with self.expect_output('detail.txt'):
-            self.runner.run(['release-info', 'release-1.0'])
+            self.runner.run(['release', 'info', 'release-1.0'])
         self.assertDictEqual(api.calls,
                              {'releases/release-1.0': [('GET', {})],
                               'release-variants': [('GET', {'page': 1, 'release': 'release-1.0'})]})
@@ -73,7 +73,7 @@ class ReleaseTestCase(CLITestCase):
         self._setup_release_detail(api)
         api.add_endpoint('releases/release-0.9', 'PATCH', self.release_detail)
         with self.expect_output('detail.txt'):
-            self.runner.run(['release-update', 'release-0.9', '--version', '1.0'])
+            self.runner.run(['release', 'update', 'release-0.9', '--version', '1.0'])
         self.assertDictEqual(api.calls,
                              {'releases/release-0.9': [('PATCH', {'version': '1.0'})],
                               'releases/release-1.0': [('GET', {})],
@@ -83,7 +83,7 @@ class ReleaseTestCase(CLITestCase):
         api.add_endpoint('releases', 'POST', self.release_detail)
         self._setup_release_detail(api)
         with self.expect_output('detail.txt'):
-            self.runner.run(['release-create', '--short', 'release',
+            self.runner.run(['release', 'create', '--short', 'release',
                              '--version', '1.0',
                              '--name', 'Test Release',
                              '--release-type', 'ga'])
@@ -98,7 +98,7 @@ class ReleaseTestCase(CLITestCase):
     def test_info_json(self, api):
         self._setup_release_detail(api)
         with self.expect_output('detail.json', parse_json=True):
-            self.runner.run(['--json', 'release-info', 'release-1.0'])
+            self.runner.run(['--json', 'release', 'info', 'release-1.0'])
         self.assertDictEqual(api.calls,
                              {'releases/release-1.0': [('GET', {})],
                               'release-variants': [('GET', {'page': 1, 'release': 'release-1.0'})]})
@@ -106,8 +106,8 @@ class ReleaseTestCase(CLITestCase):
     def test_list_json(self, api):
         api.add_endpoint('releases', 'GET', [self.release_detail])
         with self.expect_output('list.json', parse_json=True):
-            self.runner.run(['--json', 'release-list'])
+            self.runner.run(['--json', 'release', 'list'])
 
     def test_can_not_activate_and_deactivate(self, api):
         with self.expect_failure():
-            self.runner.run(['release-update', 'release-1.0', '--activate', '--deactivate'])
+            self.runner.run(['release', 'update', 'release-1.0', '--activate', '--deactivate'])

--- a/pdc_client/tests/rpm/tests.py
+++ b/pdc_client/tests/rpm/tests.py
@@ -15,7 +15,7 @@ class RpmTestCase(CLITestCase):
 
     def test_list_without_filters(self, api):
         with self.expect_failure():
-            self.runner.run(['rpm-list'])
+            self.runner.run(['rpm', 'list'])
 
     def _setup_list(self, api):
         api.add_endpoint('rpms', 'GET', [
@@ -31,7 +31,7 @@ class RpmTestCase(CLITestCase):
     def test_list(self, api):
         self._setup_list(api)
         with self.expect_output('list.txt'):
-            self.runner.run(['rpm-list', '--name', 'bash'])
+            self.runner.run(['rpm', 'list', '--name', 'bash'])
         self.assertEqual(api.calls['rpms'],
                          [('GET', {'page': 1, 'name': 'bash'}),
                           ('GET', {'page': 2, 'name': 'bash'})])
@@ -39,7 +39,7 @@ class RpmTestCase(CLITestCase):
     def test_list_json(self, api):
         self._setup_list(api)
         with self.expect_output('list.json', parse_json=True):
-            self.runner.run(['--json', 'rpm-list', '--name', 'bash'])
+            self.runner.run(['--json', 'rpm', 'list', '--name', 'bash'])
         self.assertEqual(api.calls['rpms'],
                          [('GET', {'page': 1, 'name': 'bash'}),
                           ('GET', {'page': 2, 'name': 'bash'})])
@@ -73,19 +73,19 @@ class RpmTestCase(CLITestCase):
     def test_info(self, api):
         self._setup_detail(api)
         with self.expect_output('info.txt'):
-            self.runner.run(['rpm-info', '1'])
+            self.runner.run(['rpm', 'info', '1'])
         self.assertEqual(api.calls['rpms/1'], [('GET', {})])
 
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('info.json', parse_json=True):
-            self.runner.run(['--json', 'rpm-info', '1'])
+            self.runner.run(['--json', 'rpm', 'info', '1'])
         self.assertEqual(api.calls['rpms/1'], [('GET', {})])
 
     def test_create(self, api):
         self._setup_detail(api)
         with self.expect_output('info.txt'):
-            self.runner.run(['rpm-create',
+            self.runner.run(['rpm', 'create',
                              '--name', 'bash',
                              '--srpm-name', 'bash',
                              '--epoch', '0',
@@ -101,7 +101,7 @@ class RpmTestCase(CLITestCase):
     def test_update(self, api):
         self._setup_detail(api)
         with self.expect_output('info.txt'):
-            self.runner.run(['rpm-update', '1',
+            self.runner.run(['rpm', 'update', '1',
                              '--name', 'bash',
                              '--srpm-name', 'bash',
                              '--epoch', '0',


### PR DESCRIPTION
The original command structure goes like `pdc COMMAND` and now it looks like `pdc COMMAND SUB-COMMAND`. The functions of the original commands are not altered.

JIRA: PDC-1129