### PR TITLE
Not ready to use DRFv3.3.0

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,7 +6,7 @@ https://github.com/release-engineering/productmd/archive/master.tar.gz#egg=produ
 # requires: openldap-devel
 python-ldap
 # django rest framework
-djangorestframework>=3.1
+djangorestframework<3.3
 Markdown
 django-filter==0.9.2
 django-mptt>=0.7.1


### PR DESCRIPTION
Add the limit to not use Django REST Framework v3.3.0
until we're ready.