### PR TITLE
 Restucture the webUI

### DIFF
--- a/pdc/apps/release/templates/product_pages.html
+++ b/pdc/apps/release/templates/product_pages.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h3 class="page-header">Product information</h3>
 <ul>
+    <li><a href="{% url 'base_product/index' %}">Base Products</a></li>
     <li><a href="{% url 'product/index' %}">Products</a></li>
     <li><a href="{% url 'product_version/index' %}">Product Versions</a></li>
 </li>

--- a/pdc/apps/release/templates/release_pages.html
+++ b/pdc/apps/release/templates/release_pages.html
@@ -1,9 +1,0 @@
-{% extends "base.html" %}
-
-{% block content %}
-<h3 class="page-header">Release information</h3>
-<ul>
-    <li><a href="{% url 'release/index' %}">Releases</a></li>
-    <li><a href="{% url 'base_product/index' %}">Base Products</a></li>
-</li>
-{% endblock %}

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -543,10 +543,6 @@ def product_pages(request):
     return render(request, "product_pages.html", {})
 
 
-def release_pages(request):
-    return render(request, "release_pages.html", {})
-
-
 class ReleaseCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSet):
     queryset = models.Release.objects.none()   # Required for permissions
 

--- a/pdc/urls.py
+++ b/pdc/urls.py
@@ -59,7 +59,6 @@ urlpatterns = [
     url(r"^product/$", ProductListView.as_view(), name="product/index"),
     url(r"^product/(?P<id>\d+)/$", ProductDetailView.as_view(), name="product/detail"),
     url(r'^product-index/$', release_views.product_pages, name='product_pages'),
-    url(r'^release-index/$', release_views.release_pages, name='release_pages'),
 
     url(r"^product-version/$",
         ProductVersionListView.as_view(),


### PR DESCRIPTION
 Move the base-product link from 'Releases'  to  'Products' in WebUI menu,
 At the same time, update the release view.py file;
 and remove the unreachable file.

 JIRA: PDC-1091