### PR TITLE
Add order to queryset to ensure correctness of pagination result.

### DIFF
--- a/pdc/apps/auth/views.py
+++ b/pdc/apps/auth/views.py
@@ -279,7 +279,7 @@ class PermissionViewSet(StrictQueryParamMixin,
         """
         return super(PermissionViewSet, self).list(request, *args, **kwargs)
 
-    queryset = Permission.objects.all()
+    queryset = Permission.objects.all().order_by("id")
     serializer_class = serializers.PermissionSerializer
     filter_class = filters.PermissionFilter
 
@@ -481,7 +481,7 @@ class GroupViewSet(ChangeSetUpdateModelMixin,
         """
         return super(GroupViewSet, self).update(request, *args, **kwargs)
 
-    queryset = Group.objects.all()
+    queryset = Group.objects.all().order_by('id')
     serializer_class = serializers.GroupSerializer
     filter_class = filters.GroupFilter
     Group.export = group_obj_export

--- a/pdc/apps/common/views.py
+++ b/pdc/apps/common/views.py
@@ -30,7 +30,7 @@ class ArchListView(ListView):
 
 class SigKeyListView(ListView):
     model = SigKey
-    queryset = SigKey.objects.all()
+    queryset = SigKey.objects.all().order_by('id')
     allow_empty = True
     template_name = "sigkey_list.html"
     context_object_name = "sigkey_list"
@@ -50,7 +50,7 @@ class LabelViewSet(pdc_viewsets.PDCModelViewSet):
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
     serializer_class = LabelSerializer
-    queryset = Label.objects.all()
+    queryset = Label.objects.all().order_by('id')
     filter_class = LabelFilter
 
     def create(self, request, *args, **kwargs):
@@ -225,7 +225,7 @@ class ArchViewSet(pdc_viewsets.ChangeSetCreateModelMixin,
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
     serializer_class = ArchSerializer
-    queryset = Arch.objects.all()
+    queryset = Arch.objects.all().order_by('id')
     lookup_field = 'name'
 
     def list(self, request, *args, **kwargs):
@@ -307,7 +307,7 @@ class SigKeyViewSet(pdc_viewsets.StrictQueryParamMixin,
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
     serializer_class = SigKeySerializer
-    queryset = SigKey.objects.all()
+    queryset = SigKey.objects.all().order_by('id')
     filter_class = SigKeyFilter
     lookup_field = 'key_id'
 

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -228,8 +228,8 @@ class GlobalComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
-        self.assertEqual(response.data['results'][0]['name'], 'MySQL-python')
-        self.assertEqual(response.data['results'][1]['name'], 'python')
+        self.assertEqual(response.data['results'][0]['name'], 'python')
+        self.assertEqual(response.data['results'][1]['name'], 'MySQL-python')
 
     def test_query_global_components_with_upstream(self):
         url = reverse('globalcomponent-list')

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -102,7 +102,7 @@ class GlobalComponentViewSet(viewsets.PDCModelViewSet):
 
     """
     model = GlobalComponent
-    queryset = GlobalComponent.objects.all()
+    queryset = GlobalComponent.objects.all().order_by('id')
     serializer_class = GlobalComponentSerializer
     filter_class = ComponentFilter
 
@@ -354,7 +354,7 @@ class GlobalComponentContactViewSet(HackedComponentContactMixin,
     """
 
     model = GlobalComponent
-    queryset = GlobalComponent.objects.all()
+    queryset = GlobalComponent.objects.all().order_by('id')
     serializer_class = HackedContactSerializer
     filter_class = RoleContactFilter
 
@@ -512,7 +512,7 @@ class GlobalComponentLabelViewSet(viewsets.PDCModelViewSet):
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
     model = Label
-    queryset = Label.objects.all()
+    queryset = Label.objects.all().order_by('id')
     serializer_class = LabelSerializer
     filter_class = LabelFilter
 
@@ -634,7 +634,7 @@ class ReleaseComponentTypeViewSet(viewsets.StrictQueryParamMixin,
     API endpoint that allows release_component_types to be viewed.
     """
     serializer_class = ReleaseComponentTypeSerializer
-    queryset = ReleaseComponentType.objects.all()
+    queryset = ReleaseComponentType.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """
@@ -674,7 +674,7 @@ class ReleaseComponentViewSet(viewsets.PDCModelViewSet):
 
     """
     model = ReleaseComponent
-    queryset = model.objects.all()
+    queryset = model.objects.all().order_by('id')
     serializer_class = ReleaseComponentSerializer
     filter_class = ReleaseComponentFilter
     extra_query_params = ('include_inactive_release', )
@@ -1107,7 +1107,7 @@ class ReleaseComponentContactViewSet(HackedComponentContactMixin,
     API]($URL:releasecomponentcontacts-list$) instead.
     """
     model = ReleaseComponent
-    queryset = ReleaseComponent.objects.all()
+    queryset = ReleaseComponent.objects.all().order_by('id')
     serializer_class = HackedContactSerializer
     gcc_serializer_class = HackedContactSerializer
     extra_query_params = ('contact_role', )
@@ -1351,7 +1351,7 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
 
     """
     model = BugzillaComponent
-    queryset = model.objects.all()
+    queryset = model.objects.all().order_by('id')
     serializer_class = BugzillaComponentSerializer
     filter_class = BugzillaComponentFilter
 
@@ -1592,7 +1592,7 @@ class GroupTypeViewSet(viewsets.PDCModelViewSet):
     API endpoint that allows component_group_types to be viewed or edited.
     """
     serializer_class = GroupTypeSerializer
-    queryset = GroupType.objects.all()
+    queryset = GroupType.objects.all().order_by('id')
     filter_class = GroupTypeFilter
 
     def create(self, request, *args, **kwargs):
@@ -1673,7 +1673,7 @@ class GroupViewSet(viewsets.PDCModelViewSet):
     API endpoint that allows component_groups to be viewed or edited.
     """
     serializer_class = GroupSerializer
-    queryset = ReleaseComponentGroup.objects.all()
+    queryset = ReleaseComponentGroup.objects.all().order_by('id')
     filter_class = GroupFilter
 
     def create(self, request, *args, **kwargs):
@@ -1780,7 +1780,7 @@ class ReleaseComponentRelationshipTypeViewSet(viewsets.StrictQueryParamMixin,
     API endpoint that allows release_component_relationship_types to be viewed.
     """
     serializer_class = RCRelationshipTypeSerializer
-    queryset = ReleaseComponentRelationshipType.objects.all()
+    queryset = ReleaseComponentRelationshipType.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """
@@ -1800,7 +1800,7 @@ class ReleaseComponentRelationshipViewSet(viewsets.PDCModelViewSet):
     API endpoint that allows release component relationship to be viewed or edited.
     """
     serializer_class = ReleaseComponentRelationshipSerializer
-    queryset = ReleaseComponentRelationship.objects.all()
+    queryset = ReleaseComponentRelationship.objects.all().order_by('id')
     filter_class = ReleaseComponentRelationshipFilter
 
     def create(self, request, *args, **kwargs):
@@ -1999,7 +1999,7 @@ class _BaseContactViewSet(viewsets.PDCModelViewSet):
 # TODO Remove Info from name once 0.2.0 gets out
 class GlobalComponentContactInfoViewSet(_BaseContactViewSet):
 
-    queryset = GlobalComponentContact.objects.all().select_related()
+    queryset = GlobalComponentContact.objects.all().select_related().order_by('id')
     serializer_class = GlobalComponentContactSerializer
     filter_class = GlobalComponentContactFilter
     docstring_macros = {
@@ -2011,7 +2011,7 @@ class GlobalComponentContactInfoViewSet(_BaseContactViewSet):
 # TODO Remove Info from name once 0.2.0 gets out
 class ReleaseComponentContactInfoViewSet(_BaseContactViewSet):
 
-    queryset = ReleaseComponentContact.objects.all().select_related()
+    queryset = ReleaseComponentContact.objects.all().select_related().order_by('id')
     serializer_class = ReleaseComponentContactSerializer
     filter_class = ReleaseComponentContactFilter
     docstring_macros = {

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -46,7 +46,7 @@ class ComposeListView(SearchView):
     form_class = ComposeSearchForm
     queryset = Compose.objects.all() \
         .select_related('release', 'compose_type') \
-        .prefetch_related('linked_releases')
+        .prefetch_related('linked_releases').order_by('id')
     allow_empty = True
     template_name = "compose_list.html"
     context_object_name = "compose_list"
@@ -428,7 +428,7 @@ class ComposeViewSet(StrictQueryParamMixin,
     template contains a string `{{package}}` which should be replaced with the
     package name you are interested in.
     """
-    queryset = Compose.objects.all()
+    queryset = Compose.objects.all().order_by('id')
     serializer_class = ComposeSerializer
     filter_class = ComposeFilter
     lookup_field = 'compose_id'
@@ -877,7 +877,7 @@ class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
     """
 
     serializer_class = OverrideRPMSerializer
-    queryset = OverrideRPM.objects.all()
+    queryset = OverrideRPM.objects.all().order_by('id')
     filter_class = OverrideRPMFilter
 
     def create(self, *args, **kwargs):

--- a/pdc/apps/contact/views.py
+++ b/pdc/apps/contact/views.py
@@ -144,7 +144,7 @@ class PersonViewSet(viewsets.PDCModelViewSet):
         return super(PersonViewSet, self).destroy(request, *args, **kwargs)
 
     serializer_class = PersonSerializer
-    queryset = Person.objects.all()
+    queryset = Person.objects.all().order_by('id')
     filter_class = PersonFilterSet
 
 
@@ -307,7 +307,7 @@ class MaillistViewSet(viewsets.PDCModelViewSet):
         return super(MaillistViewSet, self).destroy(request, *args, **kwargs)
 
     serializer_class = MaillistSerializer
-    queryset = Maillist.objects.all()
+    queryset = Maillist.objects.all().order_by('id')
     filter_class = MaillistFilterSet
 
 
@@ -479,7 +479,7 @@ class ContactRoleViewSet(viewsets.PDCModelViewSet):
         return super(ContactRoleViewSet, self).destroy(request, *args, **kwargs)
 
     serializer_class = ContactRoleSerializer
-    queryset = ContactRole.objects.all()
+    queryset = ContactRole.objects.all().order_by('id')
     filter_class = ContactRoleFilterSet
     lookup_field = 'name'
     overwrite_lookup_field = False
@@ -737,11 +737,11 @@ class RoleContactViewSet(viewsets.PDCModelViewSet):
         return super(RoleContactViewSet, self).destroy(request, *args, **kwargs)
 
     serializer_class = RoleContactSerializer
-    queryset = RoleContact.objects.all()
+    queryset = RoleContact.objects.all().order_by('id')
     extra_query_params = ('contact_role', 'username', 'mail_name', 'email')
 
     def get_queryset(self):
-        queryset = RoleContact.objects.all()
+        queryset = RoleContact.objects.all().order_by('id')
 
         filters = self.request.query_params
         person_kwarg = {}

--- a/pdc/apps/osbs/views.py
+++ b/pdc/apps/osbs/views.py
@@ -34,7 +34,7 @@ class OSBSViewSet(common_viewsets.StrictQueryParamMixin,
        is `null`, it indicates that the client should use its default value.
     """
 
-    queryset = models.OSBSRecord.objects.filter(component__type__has_osbs=True)
+    queryset = models.OSBSRecord.objects.filter(component__type__has_osbs=True).order_by('component__id')
     serializer_class = serializers.OSBSSerializer
     filter_class = filters.OSBSFilter
     lookup_fields = (('component__release__release_id', r'[^/]+'),

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -20,7 +20,7 @@ class RPMViewSet(pdc_viewsets.StrictQueryParamMixin,
     """
     API endpoint that allows RPMs to be viewed.
     """
-    queryset = models.RPM.objects.all()
+    queryset = models.RPM.objects.all().order_by("id")
     serializer_class = serializers.RPMSerializer
     filter_class = filters.RPMFilter
 
@@ -129,7 +129,7 @@ class ImageViewSet(pdc_viewsets.StrictQueryParamMixin,
     """
     List and query images.
     """
-    queryset = models.Image.objects.all()
+    queryset = models.Image.objects.all().order_by('id')
     serializer_class = serializers.ImageSerializer
     filter_class = filters.ImageFilter
 
@@ -159,7 +159,7 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
     """
     ViewSet for  BuildImage.
     """
-    queryset = models.BuildImage.objects.all()
+    queryset = models.BuildImage.objects.all().order_by('id')
     serializer_class = serializers.BuildImageSerializer
     filter_class = filters.BuildImageFilter
 

--- a/pdc/apps/partners/views.py
+++ b/pdc/apps/partners/views.py
@@ -20,7 +20,7 @@ from . import serializers
 class PartnerTypeViewSet(StrictQueryParamMixin,
                          mixins.ListModelMixin,
                          viewsets.GenericViewSet):
-    queryset = models.PartnerType.objects.all()
+    queryset = models.PartnerType.objects.all().order_by('id')
     serializer_class = serializers.PartnerTypeSerializer
 
     def list(self, request, *args, **kwargs):
@@ -37,7 +37,7 @@ class PartnerTypeViewSet(StrictQueryParamMixin,
 
 
 class PartnerViewSet(PDCModelViewSet):
-    queryset = models.Partner.objects.all()
+    queryset = models.Partner.objects.all().order_by('id')
     lookup_field = 'short'
     serializer_class = serializers.PartnerSerializer
     filter_class = filters.PartnerFilterSet
@@ -123,7 +123,7 @@ class PartnerMappingViewSet(StrictQueryParamMixin,
         'partner',
         'variant_arch__arch',
         'variant_arch__variant__release'
-    )
+    ).order_by('id')
     serializer_class = serializers.PartnerMappingSerializer
     lookup_fields = (
         ('partner__short', r'[^/]+'),

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -31,7 +31,7 @@ from . import lib
 
 class ReleaseListView(SearchView):
     form_class = ReleaseSearchForm
-    queryset = models.Release.objects.select_related('release_type', 'product_version', 'base_product')
+    queryset = models.Release.objects.select_related('release_type', 'product_version', 'base_product').order_by('id')
     allow_empty = True
     template_name = "release_list.html"
     context_object_name = "release_list"
@@ -56,7 +56,7 @@ class ReleaseDetailView(DetailView):
 
 class BaseProductListView(SearchView):
     form_class = BaseProductSearchForm
-    queryset = models.BaseProduct.objects.all()
+    queryset = models.BaseProduct.objects.all().order_by('id')
     allow_empty = True
     template_name = "base_product_list.html"
     context_object_name = "base_product_list"
@@ -79,7 +79,7 @@ class BaseProductDetailView(DetailView):
 
 class ProductListView(SearchView):
     form_class = ProductSearchForm
-    queryset = models.Product.objects.prefetch_related('productversion_set__release_set')
+    queryset = models.Product.objects.prefetch_related('productversion_set__release_set').order_by('id')
     allow_empty = True
     template_name = "product_list.html"
     context_object_name = "product_list"
@@ -106,7 +106,7 @@ class ProductViewSet(ChangeSetCreateModelMixin,
     the form of `product_version_id` (both in requests and responses).
     """
 
-    queryset = models.Product.objects.prefetch_related('productversion_set')
+    queryset = models.Product.objects.prefetch_related('productversion_set').order_by('id')
     serializer_class = ProductSerializer
     lookup_field = 'short'
     filter_class = filters.ProductFilter
@@ -189,7 +189,7 @@ class ProductVersionViewSet(ChangeSetCreateModelMixin,
     `short` name. Similarly releases are referenced by `release_id`. This
     applies to both requests and responses.
     """
-    queryset = models.ProductVersion.objects.select_related('product').prefetch_related('release_set')
+    queryset = models.ProductVersion.objects.select_related('product').prefetch_related('release_set').order_by('id')
     serializer_class = ProductVersionSerializer
     lookup_field = 'product_version_id'
     lookup_value_regex = '[^/]+'
@@ -289,7 +289,7 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
     """
     queryset = models.Release.objects \
                      .select_related('product_version', 'release_type', 'base_product') \
-                     .prefetch_related('compose_set')
+                     .prefetch_related('compose_set').order_by('id')
     serializer_class = ReleaseSerializer
     lookup_field = 'release_id'
     lookup_value_regex = '[^/]+'
@@ -456,7 +456,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
     """
     An API endpoint providing access to base products.
     """
-    queryset = models.BaseProduct.objects.all()
+    queryset = models.BaseProduct.objects.all().order_by('id')
     serializer_class = BaseProductSerializer
     lookup_field = 'base_product_id'
     lookup_value_regex = '[^/]+'
@@ -525,7 +525,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
 
 class ProductVersionListView(SearchView):
     form_class = ProductVersionSearchForm
-    queryset = models.ProductVersion.objects.prefetch_related('release_set')
+    queryset = models.ProductVersion.objects.prefetch_related('release_set').order_by('id')
     allow_empty = True
     template_name = "product_version_list.html"
     context_object_name = "product_version_list"
@@ -704,7 +704,7 @@ class ReleaseTypeViewSet(StrictQueryParamMixin,
     -d _data_ (a json string). or GUI plugins for
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
-    queryset = models.ReleaseType.objects.all()
+    queryset = models.ReleaseType.objects.all().order_by('id')
     serializer_class = ReleaseTypeSerializer
     filter_class = filters.ReleaseTypeFilter
 
@@ -752,7 +752,7 @@ class ReleaseVariantViewSet(ChangeSetModelMixin,
     `release_id/variant_uid` is used in URL for retrieving, updating or
     deleting a single variant as well as in bulk operations.
     """
-    queryset = models.Variant.objects.all()
+    queryset = models.Variant.objects.all().order_by('id')
     serializer_class = ReleaseVariantSerializer
     filter_class = filters.ReleaseVariantFilter
     lookup_fields = (('release__release_id', r'[^/]+'), ('variant_uid', r'[^/]+'))
@@ -888,7 +888,7 @@ class VariantTypeViewSet(StrictQueryParamMixin,
     API endpoint that allows variant_types to be viewed.
     """
     serializer_class = VariantTypeSerializer
-    queryset = models.VariantType.objects.all()
+    queryset = models.VariantType.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """

--- a/pdc/apps/repository/views.py
+++ b/pdc/apps/repository/views.py
@@ -32,7 +32,7 @@ class RepoViewSet(ChangeSetCreateModelMixin,
     Please access this endpoint by [%(HOST_NAME)s/%(API_PATH)s/content-delivery-repos/](/%(API_PATH)s/content-delivery-repos/).
     Endpoint [%(HOST_NAME)s/%(API_PATH)s/repos/](/%(API_PATH)s/repos/) is deprecated.
     """
-    queryset = models.Repo.objects.all().select_related()
+    queryset = models.Repo.objects.all().select_related().order_by('id')
     serializer_class = serializers.RepoSerializer
     filter_class = filters.RepoFilter
 
@@ -258,7 +258,7 @@ class RepoFamilyViewSet(StrictQueryParamMixin,
     -d _data_ (a json string). or GUI plugins for
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
-    queryset = models.RepoFamily.objects.all()
+    queryset = models.RepoFamily.objects.all().order_by('id')
     serializer_class = serializers.RepoFamilySerializer
     filter_class = filters.RepoFamilyFilter
 
@@ -309,7 +309,7 @@ class ContentCategoryViewSet(StrictQueryParamMixin,
     API endpoint that allows content_category to be viewed.
     """
     serializer_class = serializers.ContentCategorySerializer
-    queryset = models.ContentCategory.objects.all()
+    queryset = models.ContentCategory.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """
@@ -331,7 +331,7 @@ class ContentFormatViewSet(StrictQueryParamMixin,
     API endpoint that allows content_format to be viewed.
     """
     serializer_class = serializers.ContentFormatSerializer
-    queryset = models.ContentFormat.objects.all()
+    queryset = models.ContentFormat.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """
@@ -353,7 +353,7 @@ class ServiceViewSet(StrictQueryParamMixin,
     API endpoint that allows service to be viewed.
     """
     serializer_class = serializers.ServiceSerializer
-    queryset = models.Service.objects.all()
+    queryset = models.Service.objects.all().order_by('id')
 
     def list(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
Originally, rows of querysets is in unspecified order if sorting is not chosen.
This causes problem when django pagination is used.
It can only be guaranteed if the sort type if explicitly chosen.

JIRA: PDC-1063