### PR TITLE
Add missing filters to partners list

### DIFF
--- a/pdc/apps/partners/filters.py
+++ b/pdc/apps/partners/filters.py
@@ -14,10 +14,12 @@ class PartnerFilterSet(django_filters.FilterSet):
     enabled = filters.CaseInsensitiveBooleanFilter()
     binary = filters.CaseInsensitiveBooleanFilter()
     source = filters.CaseInsensitiveBooleanFilter()
+    name = django_filters.CharFilter(lookup_type='icontains')
+    type = django_filters.CharFilter(name='type__name')
 
     class Meta:
         model = models.Partner
-        fields = ('short', 'enabled', 'binary', 'source', 'ftp_dir', 'rsync_dir')
+        fields = ('short', 'name', 'type', 'enabled', 'binary', 'source', 'ftp_dir', 'rsync_dir')
 
 
 class PartnerMappingFilterSet(django_filters.FilterSet):

--- a/pdc/apps/partners/tests.py
+++ b/pdc/apps/partners/tests.py
@@ -140,6 +140,16 @@ class PartnerAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 0)
 
+    def test_filter_by_name(self):
+        response = self.client.get(reverse('partner-list'), {'name': 'acme'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 1)
+
+    def test_filter_by_type(self):
+        response = self.client.get(reverse('partner-list'), {'type': 'partner'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 0)
+
 
 class PartnerMappingAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [


### PR DESCRIPTION
It should be possible to filter partners by name or type. Tests have
been added to verify this feature is present.

JIRA: PDC-1164