### PR TITLE
Exclude pdc-client from distribution package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ recursive-include requirements *
 recursive-include conf *
 recursive-include contrib *
 recursive-include docs *
-recursive-include pdc_client *
+recursive-exclude pdc_client *
 recursive-exclude docs/build *
 recursive-exclude tests *
 exclude pdc/settings_local.py


### PR DESCRIPTION
JIRA: PDC-1094

Exclude the pdc_client module as it is packaged independently with tito